### PR TITLE
fix(db-guard): enforce bypass on auth + idempotent bootstrap + better logging

### DIFF
--- a/server/admin-routes.ts
+++ b/server/admin-routes.ts
@@ -545,7 +545,7 @@ adminRouter.get("/users/:userId/export", async (req: Request, res: Response) => 
 
 // Helper function to log system events
 export async function logSystemEvent(level: 'info' | 'warning' | 'error', message: string, source: string, userId?: number, metadata?: any) {
-  if (!isDbAvailable()) {
+  if (!(await isDbAvailable())) {
     return;
   }
   try {

--- a/server/db-storage-enhanced.ts
+++ b/server/db-storage-enhanced.ts
@@ -1336,7 +1336,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   async logSystemEvent(level: string, message: string, source: string, userId?: number, metadata?: any): Promise<void> {
-    if (!isDbAvailable()) {
+    if (!(await isDbAvailable())) {
       return;
     }
     try {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -115,7 +115,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       schema: undefined as string | undefined,
       tables: [] as string[],
       hostMasked: mask(process.env.DATABASE_URL),
-      guard: { bypass: dbGuard.bypass, reason: dbGuard.reason },
+      guard: { bypass: dbGuard.bypass, reason: dbGuard.reason, cachedDown: dbGuard.cachedDown },
     };
 
     try {


### PR DESCRIPTION
## Summary
- add global `isDbAvailable` helper with bypass, 2s SELECT 1 check and negative cache
- ensure auth routes honor DB_GUARD_BYPASS and log Postgres error details
- make bootstrap idempotent and expose guard diagnostics

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check` *(fails: TypeScript errors in client pages)*

## Render instructions
- Set `DB_GUARD_BYPASS=1` and `RUN_MIGRATIONS_ON_START=0`
- Restart service and observe logs:
  - `db bootstrap: skipped (bypass)` or `db bootstrap: ok (applied X, skipped Y)`
  - On schema issues, auth routes log: `Register error: { code: '42703', column: 'foo', table: 'users' }`


------
https://chatgpt.com/codex/tasks/task_e_68a85bbe416c832c9502fead71c30d05