### PR TITLE
codex/sessions-pg-store

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,7 @@
 BASE_URL=https://www.mylinked.app
 
+SESSION_SECRET=changeme
+
 # Google OAuth Configuration
 GOOGLE_CLIENT_ID=261635806314-m1jpnkbjffsrg75ir3oklaaj5pkl18g3.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=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

--- a/deployment-checklist.md
+++ b/deployment-checklist.md
@@ -7,7 +7,7 @@
 - [ ] All dependencies installed (`package.json` up to date)
 - [ ] Build process works: `npm run build`
 - [ ] Server starts properly: `npm start`
-- [ ] Environment variables configured
+- [ ] Environment variables configured (e.g., `SESSION_SECRET`)
 
 ### ✅ Domain Strategy Decision
 Choose ONE:


### PR DESCRIPTION
## Summary
- configure Express to use a Postgres-backed session store when running in production
- simplify auth setup to rely on global session middleware
- document SESSION_SECRET in environment configuration

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8fd8c25e4832ca18bb9565c9b918b