### PR TITLE
fix(theme): wire Settings to ThemeProvider for immediate apply

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,7 +12,6 @@ import NotFound from "./pages/not-found";
 import PrivacyPolicy from "./pages/privacy-policy";
 import TermsOfService from "./pages/terms-of-service";
 import { useAuth, AuthProvider } from "./hooks/use-auth";
-import { ThemeProvider } from "./hooks/use-theme";
 import { ProtectedRoute } from "./lib/protected-route";
 import { AdminProtectedRoute } from "./lib/admin-protected-route";
 import { Award, Loader2 } from "lucide-react";
@@ -49,6 +48,7 @@ import MyLinksPage from "./pages/my-links";
 import ForgotPasswordPage from "./pages/forgot-password";
 import ResetPasswordPage from "./pages/reset-password";
 import CollaborationPage from "./pages/collaboration-page";
+import ThemeDebug from "./dev/ThemeDebug";
 
 // Deprecated landing page - use the new component instead
 function OldLandingPage() {
@@ -200,13 +200,14 @@ function App() {
     return (
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <ThemeProvider>
-            <ErrorBoundary>
+          <ErrorBoundary>
+            <div className="min-h-screen bg-base-200 text-base-content">
               <Router />
               <AIChatbot />
-            </ErrorBoundary>
-            <Toaster />
-          </ThemeProvider>
+              <ThemeDebug />
+              <Toaster />
+            </div>
+          </ErrorBoundary>
         </AuthProvider>
       </QueryClientProvider>
     );

--- a/client/src/dev/ThemeDebug.tsx
+++ b/client/src/dev/ThemeDebug.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export default function ThemeDebug() {
+  if (import.meta.env.PROD) return null;
+
+  const read = () => ({
+    attr: document.documentElement.getAttribute('data-theme'),
+    dark: document.documentElement.classList.contains('dark'),
+    b1: getComputedStyle(document.documentElement).getPropertyValue('--b1').trim(),
+    b2: getComputedStyle(document.documentElement).getPropertyValue('--b2').trim(),
+    bc: getComputedStyle(document.documentElement).getPropertyValue('--bc').trim(),
+  });
+
+  const [info, setInfo] = React.useState(read());
+
+  React.useEffect(() => {
+    const obs = new MutationObserver(() => setInfo(read()));
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div style={{
+      position: 'fixed', right: 8, bottom: 8, fontSize: 12,
+      padding: '6px 8px', background: 'rgba(0,0,0,.5)', color: '#fff', borderRadius: 6, zIndex: 99999
+    }}>
+      <div>theme: <b>{info.attr}</b></div>
+      <div>dark class: {String(info.dark)}</div>
+      <div>--b2: {info.b2}</div>
+      <div>--bc: {info.bc}</div>
+    </div>
+  );
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,7 @@
+import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ThemeProvider } from "./hooks/use-theme";
 import "./index.css";
 
 // ensure all fetch requests include credentials
@@ -11,5 +13,9 @@ window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
 
 // Use the App component with our authentication system
 createRoot(document.getElementById("root")!).render(
-  <App />
+  <React.StrictMode>
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
 );

--- a/client/src/pages/simple-themes-demo.tsx
+++ b/client/src/pages/simple-themes-demo.tsx
@@ -20,7 +20,7 @@ import {
 import { useLocation } from "wouter";
 import { useToast } from "@/hooks/use-toast";
 import { useQuery } from "@tanstack/react-query";
-import { useApplyTheme } from "@/hooks/use-theme";
+import { useTheme } from "@/hooks/use-theme";
 import { useAuth } from "@/hooks/use-auth";
 import { User } from "@shared/schema";
 
@@ -42,7 +42,7 @@ interface Theme {
 
 const presetThemes: Theme[] = [
   {
-    id: "ocean",
+    id: "light",
     name: "Ocean Blue",
     description: "Professional and trustworthy",
     icon: <Waves className="h-5 w-5" />,
@@ -87,7 +87,7 @@ const presetThemes: Theme[] = [
     gradient: "linear-gradient(135deg, #059669 0%, #34d399 100%)"
   },
   {
-    id: "midnight",
+    id: "night",
     name: "Midnight Dark",
     description: "Sleek and modern",
     icon: <Moon className="h-5 w-5" />,
@@ -102,7 +102,7 @@ const presetThemes: Theme[] = [
     gradient: "linear-gradient(135deg, #6366f1 0%, #a78bfa 100%)"
   },
   {
-    id: "passion",
+    id: "valentine",
     name: "Passion Red",
     description: "Bold and energetic",
     icon: <Flame className="h-5 w-5" />,
@@ -117,7 +117,7 @@ const presetThemes: Theme[] = [
     gradient: "linear-gradient(135deg, #dc2626 0%, #f87171 100%)"
   },
   {
-    id: "royal",
+    id: "luxury",
     name: "Royal Purple",
     description: "Elegant and sophisticated",
     icon: <Crown className="h-5 w-5" />,
@@ -138,9 +138,9 @@ export default function SimpleThemesDemo() {
   const [, navigate] = useLocation();
   const { user } = useAuth();
   const [selectedTheme, setSelectedTheme] = useState<Theme>(presetThemes[0]);
-  const [activeTheme, setActiveTheme] = useState<string>("ocean");
+  const [activeTheme, setActiveTheme] = useState<string>("light");
   const [isDarkMode, setIsDarkMode] = useState(false);
-  const applyTheme = useApplyTheme();
+  const { setTheme } = useTheme();
 
   // Get current user profile to check active theme
   const { data: profile } = useQuery<User>({
@@ -155,9 +155,13 @@ export default function SimpleThemesDemo() {
     }
   }, [profile?.theme]);
 
-  const handleApplyTheme = (theme: Theme) => {
+  const handleApplyTheme = async (theme: Theme) => {
     setActiveTheme(theme.id);
-    applyTheme.mutate(theme.id);
+    try {
+      await setTheme(theme.id);
+    } catch (e) {
+      console.error('Failed to persist theme', e);
+    }
   };
 
   const handleDarkModeToggle = () => {

--- a/client/src/pages/themes-page.tsx
+++ b/client/src/pages/themes-page.tsx
@@ -24,7 +24,7 @@ import {
   Save
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { useApplyTheme } from "@/hooks/use-theme";
+import { useTheme } from "@/hooks/use-theme";
 import { User } from "@shared/schema";
 
 interface Theme {
@@ -45,7 +45,7 @@ interface Theme {
 
 const presetThemes: Theme[] = [
   {
-    id: "default",
+    id: "light",
     name: "Ocean Blue",
     description: "Professional and trustworthy",
     icon: <Waves className="h-5 w-5" />,
@@ -90,7 +90,7 @@ const presetThemes: Theme[] = [
     gradient: "linear-gradient(135deg, #059669 0%, #34d399 100%)"
   },
   {
-    id: "midnight",
+    id: "night",
     name: "Midnight Dark",
     description: "Sleek and modern",
     icon: <Moon className="h-5 w-5" />,
@@ -105,7 +105,7 @@ const presetThemes: Theme[] = [
     gradient: "linear-gradient(135deg, #6366f1 0%, #a78bfa 100%)"
   },
   {
-    id: "passion",
+    id: "valentine",
     name: "Passion Red",
     description: "Bold and energetic",
     icon: <Flame className="h-5 w-5" />,
@@ -120,7 +120,7 @@ const presetThemes: Theme[] = [
     gradient: "linear-gradient(135deg, #dc2626 0%, #f87171 100%)"
   },
   {
-    id: "royal",
+    id: "luxury",
     name: "Royal Purple",
     description: "Elegant and sophisticated",
     icon: <Crown className="h-5 w-5" />,
@@ -139,7 +139,7 @@ const presetThemes: Theme[] = [
 export default function ThemesPage() {
   const { user } = useAuth();
   const [selectedTheme, setSelectedTheme] = useState<Theme>(presetThemes[0]);
-  const applyTheme = useApplyTheme();
+  const { setTheme } = useTheme();
   const [customColors, setCustomColors] = useState({
     primary: "#3b82f6",
     secondary: "#1e40af",
@@ -155,8 +155,12 @@ export default function ThemesPage() {
     enabled: !!user
   });
 
-  const handleSaveTheme = (theme: Theme) => {
-    applyTheme.mutate(theme.id);
+  const handleSaveTheme = async (theme: Theme) => {
+    try {
+      await setTheme(theme.id);
+    } catch (e) {
+      console.error('Failed to persist theme', e);
+    }
   };
 
   const handleCustomColorChange = (colorType: string, value: string) => {
@@ -287,10 +291,9 @@ export default function ThemesPage() {
                       Preview
                     </Button>
                     
-                    <Button 
+                    <Button
                       size="sm"
                       onClick={() => handleSaveTheme(theme)}
-                      disabled={applyTheme.isPending}
                     >
                       <Save className="h-4 w-4 mr-1" />
                       Apply
@@ -426,10 +429,9 @@ export default function ThemesPage() {
                   </div>
                 </div>
                 
-                <Button 
+                <Button
                   className="w-full"
                   onClick={() => handleSaveTheme(createCustomTheme())}
-                  disabled={applyTheme.isPending}
                 >
                   <Save className="h-4 w-4 mr-2" />
                   Save Custom Theme


### PR DESCRIPTION
## Summary
- mount ThemeProvider at app root and expose setTheme for optimistic theme changes
- route theme selection through provider and align IDs with DaisyUI presets
- include dev-only ThemeDebug overlay to inspect current theme variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aaeb377ae4832cb54756421cbf7287