### PR TITLE
fix(query): add @tanstack/react-query QueryClientProvider at app root

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -36,10 +36,7 @@ import EnhancedAdminPanel from "./pages/enhanced-admin-panel";
 import ProfessionalAdminDashboard from "./pages/professional-admin-dashboard";
 import AdminLogin from "./pages/admin-login";
 import AcceptInvitePage from "./pages/accept-invite";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { queryClient } from "./lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
-import ErrorBoundary from "@/components/ui/error-boundary";
 import ScrollToTop from "@/components/ui/scroll-to-top";
 import { AIChatbot } from "@/components/ai-chatbot";
 import ContactPage from "./pages/contact-page";
@@ -195,20 +192,16 @@ function Router() {
 function App() {
   // Log that the App component is running
   console.log("App component rendering");
-  
+
   try {
     return (
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <ThemeProvider>
-            <ErrorBoundary>
-              <Router />
-              <AIChatbot />
-            </ErrorBoundary>
-            <Toaster />
-          </ThemeProvider>
-        </AuthProvider>
-      </QueryClientProvider>
+      <AuthProvider>
+        <ThemeProvider>
+          <Router />
+          <AIChatbot />
+          <Toaster />
+        </ThemeProvider>
+      </AuthProvider>
     );
   } catch (error) {
     console.error("Error in App component:", error);

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -24,11 +24,13 @@ export async function apiRequest(method: string, url: string, data?: any) {
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      refetchInterval: false,
+      staleTime: 30_000,
       refetchOnWindowFocus: false,
-      staleTime: Infinity,
-      retry: false,
+      retry: 1,
+      gcTime: 5 * 60 * 1000,
     },
-    mutations: { retry: false },
+    mutations: {
+      retry: 0,
+    },
   },
 });

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,13 @@
-import { createRoot } from "react-dom/client";
+import React from "react";
+import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { queryClient } from "./lib/queryClient";
+import { ThemeProvider } from "@/hooks/use-theme";
+import ErrorBoundary from "@/components/ui/error-boundary";
 
 // ensure all fetch requests include credentials
 const originalFetch = window.fetch;
@@ -9,7 +16,27 @@ window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
   return originalFetch(input, finalInit);
 };
 
-// Use the App component with our authentication system
-createRoot(document.getElementById("root")!).render(
-  <App />
+const rootEl = document.getElementById("root");
+if (!rootEl) {
+  const div = document.createElement("pre");
+  div.textContent = "FATAL: #root element not found";
+  div.style.cssText = "color:#fff;background:#c00;padding:12px";
+  document.body.appendChild(div);
+  throw new Error("Root element #root not found");
+}
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
+        {import.meta.env.DEV && (
+          <ReactQueryDevtools initialIsOpen={false} />
+        )}
+      </QueryClientProvider>
+    </ErrorBoundary>
+  </React.StrictMode>
 );
+

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-tooltip": "^1.2.0",
     "@sendgrid/mail": "^8.1.5",
     "@tanstack/react-query": "^5.76.0",
+    "@tanstack/react-query-devtools": "^5.51.21",
     "@types/bcrypt": "^6.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/memoizee": "^0.4.12",


### PR DESCRIPTION
## Summary
- add react-query-devtools dependency
- centralize query client with sensible defaults
- wrap SPA with QueryClientProvider and devtools

## Testing
- `npm test` (fails: Missing script)
- `npm run check` (fails: type errors in unrelated files)
- `npm install` (fails: 403 Forbidden fetching @tanstack/react-query-devtools)


------
https://chatgpt.com/codex/tasks/task_e_68aaf2bde218832c83dc2a773f3f4610