### PR TITLE
fix: apply theme to headers and cards

### DIFF
--- a/client/src/components/app-header.tsx
+++ b/client/src/components/app-header.tsx
@@ -99,11 +99,11 @@ const AppHeader: React.FC = () => {
                       </SheetClose>
                     );
                   })}
-                  <div className="h-px bg-gray-200 my-3"></div>
+                  <div className="h-px bg-border my-3"></div>
                   <SheetClose asChild>
                     <WouterLink
                       href={`/profile/${user.username}`}
-                      className="flex items-center gap-3 py-2 px-4 rounded-lg text-gray-600 hover:bg-gray-50"
+                      className="flex items-center gap-3 py-2 px-4 rounded-lg text-muted-foreground hover:bg-muted"
                     >
                       <User className="h-5 w-5" />
                       Your Profile
@@ -112,7 +112,7 @@ const AppHeader: React.FC = () => {
                   <SheetClose asChild>
                     <WouterLink
                       href="/themes"
-                      className="flex items-center gap-3 py-2 px-4 rounded-lg text-gray-600 hover:bg-gray-50"
+                      className="flex items-center gap-3 py-2 px-4 rounded-lg text-muted-foreground hover:bg-muted"
                     >
                       <Palette className="h-5 w-5" />
                       Themes
@@ -121,7 +121,7 @@ const AppHeader: React.FC = () => {
                   <SheetClose asChild>
                     <WouterLink
                       href="/settings"
-                      className="flex items-center gap-3 py-2 px-4 rounded-lg text-gray-600 hover:bg-gray-50"
+                      className="flex items-center gap-3 py-2 px-4 rounded-lg text-muted-foreground hover:bg-muted"
                     >
                       <Settings className="h-5 w-5" />
                       Settings
@@ -130,14 +130,14 @@ const AppHeader: React.FC = () => {
                   <SheetClose asChild>
                     <WouterLink
                       href="/support"
-                      className="flex items-center gap-3 py-2 px-4 rounded-lg text-gray-600 hover:bg-gray-50"
+                      className="flex items-center gap-3 py-2 px-4 rounded-lg text-muted-foreground hover:bg-muted"
                     >
                       <HelpCircle className="h-5 w-5" />
                       Support
                     </WouterLink>
                   </SheetClose>
                   <button
-                    className="flex items-center gap-3 py-2 px-4 rounded-lg text-red-600 hover:bg-red-50 w-full text-left"
+                    className="flex items-center gap-3 py-2 px-4 rounded-lg text-destructive hover:bg-destructive/10 w-full text-left"
                     onClick={() => {
                       // Set loading state
                       setIsLoggingOut(true);
@@ -182,7 +182,7 @@ const AppHeader: React.FC = () => {
                   key={item.href}
                   href={item.href}
                   className={`${
-                    isActive ? "text-primary-600 font-medium" : "text-gray-600 hover:text-primary-600"
+                    isActive ? "text-primary font-medium" : "text-muted-foreground hover:text-primary"
                   } transition-colors`}
                 >
                   {item.label}
@@ -193,7 +193,7 @@ const AppHeader: React.FC = () => {
             <WouterLink 
               href="/social-score"
               className={`${
-                location === "/social-score" ? "text-primary-600 font-medium" : "text-gray-600 hover:text-primary-600"
+                location === "/social-score" ? "text-primary font-medium" : "text-muted-foreground hover:text-primary"
               } transition-colors flex items-center gap-1`}
             >
               <Award className="h-4 w-4" />
@@ -202,7 +202,7 @@ const AppHeader: React.FC = () => {
             
             <SocialScoreMini />
             
-            <div className="h-5 w-px bg-gray-200"></div>
+            <div className="h-5 w-px bg-border"></div>
             
 
             
@@ -213,7 +213,7 @@ const AppHeader: React.FC = () => {
                 className="flex items-center gap-2 hover:bg-transparent"
                 onClick={() => setDropdownOpen(!dropdownOpen)}
               >
-                <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center overflow-hidden">
+                <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center overflow-hidden">
                   {user.profileImage ? (
                     <img
                       src={user.profileImage}
@@ -221,20 +221,20 @@ const AppHeader: React.FC = () => {
                       className="w-full h-full object-cover"
                     />
                   ) : (
-                    <span className="text-gray-600 font-medium text-sm">
+                    <span className="text-muted-foreground font-medium text-sm">
                       {user.name ? user.name.charAt(0).toUpperCase() : user.username.charAt(0).toUpperCase()}
                     </span>
                   )}
                 </div>
                 <span className="text-sm font-medium">{user.name || user.username}</span>
-                <ChevronDown className="h-4 w-4 text-gray-500" />
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
               </Button>
               
               {dropdownOpen && (
-                <div className="absolute right-0 top-full mt-2 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
+                  <div className="absolute right-0 top-full mt-2 w-64 bg-card border border-border rounded-lg shadow-lg z-50">
                   <div className="py-1">
                     <div 
-                      className="flex items-center w-full p-3 text-left hover:bg-gray-50 cursor-pointer border-b border-gray-100"
+                      className="flex items-center w-full p-3 text-left hover:bg-muted cursor-pointer border-b border-border"
                       onClick={() => {
                         setDropdownOpen(false);
                         window.location.href = `/profile/${user.username}`;
@@ -244,7 +244,7 @@ const AppHeader: React.FC = () => {
                       <span>Profile</span>
                     </div>
                     <div 
-                      className="flex items-center w-full p-3 text-left hover:bg-gray-50 cursor-pointer border-b border-gray-100"
+                      className="flex items-center w-full p-3 text-left hover:bg-muted cursor-pointer border-b border-border"
                       onClick={() => {
                         setDropdownOpen(false);
                         window.location.href = '/themes';
@@ -254,7 +254,7 @@ const AppHeader: React.FC = () => {
                       <span>Themes</span>
                     </div>
                     <div 
-                      className="flex items-center w-full p-3 text-left hover:bg-gray-50 cursor-pointer border-b border-gray-100"
+                      className="flex items-center w-full p-3 text-left hover:bg-muted cursor-pointer border-b border-border"
                       onClick={() => {
                         setDropdownOpen(false);
                         window.location.href = '/settings';
@@ -264,7 +264,7 @@ const AppHeader: React.FC = () => {
                       <span>Settings</span>
                     </div>
                     <div 
-                      className="flex items-center w-full p-3 text-left hover:bg-blue-50 cursor-pointer text-blue-600 font-medium border-b border-blue-200 bg-blue-50"
+                        className="flex items-center w-full p-3 text-left hover:bg-primary/10 cursor-pointer text-primary font-medium border-b border-border bg-primary/10"
                       onClick={() => {
                         console.log('Support menu clicked');
                         setDropdownOpen(false);
@@ -275,7 +275,7 @@ const AppHeader: React.FC = () => {
                       <span>Support</span>
                     </div>
                     <div 
-                      className="flex items-center w-full p-3 text-left hover:bg-red-50 cursor-pointer text-red-600 mt-2"
+                      className="flex items-center w-full p-3 text-left hover:bg-destructive/10 cursor-pointer text-destructive mt-2"
                       onClick={() => {
                         setDropdownOpen(false);
                         setIsLoggingOut(true);

--- a/client/src/hooks/use-theme.tsx
+++ b/client/src/hooks/use-theme.tsx
@@ -28,15 +28,19 @@ export const getThemeColors = (themeId: string) => {
         accent: '188 91% 43%',
         background: '0 0% 100%',
         foreground: '220 14% 18%',
-        border: '220 13% 91%'
+        border: '220 13% 91%',
+        card: '0 0% 100%',
+        cardForeground: '220 14% 18%'
       },
       'default': { // Same as ocean for themes-page.tsx compatibility
         primary: '217 91% 60%',
-        secondary: '221 83% 40%', 
+        secondary: '221 83% 40%',
         accent: '188 91% 43%',
         background: '0 0% 100%',
         foreground: '220 14% 18%',
-        border: '220 13% 91%'
+        border: '220 13% 91%',
+        card: '0 0% 100%',
+        cardForeground: '220 14% 18%'
       },
       'sunset': {
         primary: '24 95% 53%', // Orange
@@ -44,7 +48,9 @@ export const getThemeColors = (themeId: string) => {
         accent: '43 96% 56%',
         background: '48 100% 96%',
         foreground: '30 95% 19%',
-        border: '24 100% 83%'
+        border: '24 100% 83%',
+        card: '0 0% 100%',
+        cardForeground: '30 95% 19%'
       },
       'forest': {
         primary: '158 64% 52%', // Green
@@ -52,7 +58,9 @@ export const getThemeColors = (themeId: string) => {
         accent: '154 71% 59%',
         background: '138 76% 97%',
         foreground: '166 84% 15%',
-        border: '142 69% 82%'
+        border: '142 69% 82%',
+        card: '0 0% 100%',
+        cardForeground: '166 84% 15%'
       },
       'midnight': {
         primary: '243 75% 59%', // Purple
@@ -60,15 +68,19 @@ export const getThemeColors = (themeId: string) => {
         accent: '258 90% 66%',
         background: '222 84% 5%',
         foreground: '213 31% 91%',
-        border: '215 28% 17%'
+        border: '215 28% 17%',
+        card: '222 84% 7%',
+        cardForeground: '213 31% 91%'
       },
       'royal': {
-        primary: '262 83% 58%', // Royal purple  
+        primary: '262 83% 58%', // Royal purple
         secondary: '263 70% 50%',
         accent: '270 91% 65%',
         background: '270 100% 98%', // Light purple background
         foreground: '270 91% 27%', // Dark purple text
-        border: '270 40% 85%' // Purple border
+        border: '270 40% 85%', // Purple border
+        card: '0 0% 100%',
+        cardForeground: '270 91% 27%'
       },
       'passion': {
         primary: '0 78% 50%', // Passion red
@@ -76,7 +88,9 @@ export const getThemeColors = (themeId: string) => {
         accent: '0 70% 70%',
         background: '0 93% 97%', // Light red background
         foreground: '0 73% 25%', // Dark red text
-        border: '0 93% 83%' // Red border
+        border: '0 93% 83%', // Red border
+        card: '0 0% 100%',
+        cardForeground: '0 73% 25%'
       },
       'vibrant': {
         primary: '24 95% 53%', // Vibrant orange
@@ -84,7 +98,9 @@ export const getThemeColors = (themeId: string) => {
         accent: '43 96% 56%',
         background: '0 0% 100%',
         foreground: '20 14% 4%',
-        border: '20 6% 90%'
+        border: '20 6% 90%',
+        card: '0 0% 100%',
+        cardForeground: '20 14% 4%'
       },
       'minimal': {
         primary: '220 9% 46%', // Gray
@@ -92,7 +108,9 @@ export const getThemeColors = (themeId: string) => {
         accent: '220 13% 69%',
         background: '0 0% 100%',
         foreground: '220 9% 46%',
-        border: '220 13% 91%'
+        border: '220 13% 91%',
+        card: '0 0% 100%',
+        cardForeground: '220 9% 46%'
       },
       'professional': {
         primary: '243 75% 59%', // Indigo
@@ -100,7 +118,9 @@ export const getThemeColors = (themeId: string) => {
         accent: '258 90% 66%',
         background: '0 0% 100%',
         foreground: '220 14% 18%',
-        border: '220 13% 91%'
+        border: '220 13% 91%',
+        card: '0 0% 100%',
+        cardForeground: '220 14% 18%'
       }
     };
 
@@ -175,6 +195,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         document.documentElement.style.setProperty('--background', themeColors.background);
         document.documentElement.style.setProperty('--foreground', themeColors.foreground);
         document.documentElement.style.setProperty('--border', themeColors.border);
+        document.documentElement.style.setProperty('--card', themeColors.card);
+        document.documentElement.style.setProperty('--card-foreground', themeColors.cardForeground);
+        document.documentElement.style.setProperty('--card', themeColors.card);
+        document.documentElement.style.setProperty('--card-foreground', themeColors.cardForeground);
       }
       
       // Apply font style to body
@@ -230,13 +254,15 @@ export function useApplyTheme() {
         document.body.classList.add(`theme-${theme}`);
 
         // Immediately apply CSS variables for the selected theme
-        const themeColors = getThemeColors(theme);
-        document.documentElement.style.setProperty('--primary', themeColors.primary);
-        document.documentElement.style.setProperty('--secondary', themeColors.secondary);
-        document.documentElement.style.setProperty('--accent', themeColors.accent);
-        document.documentElement.style.setProperty('--background', themeColors.background);
-        document.documentElement.style.setProperty('--foreground', themeColors.foreground);
-        document.documentElement.style.setProperty('--border', themeColors.border);
+          const themeColors = getThemeColors(theme);
+          document.documentElement.style.setProperty('--primary', themeColors.primary);
+          document.documentElement.style.setProperty('--secondary', themeColors.secondary);
+          document.documentElement.style.setProperty('--accent', themeColors.accent);
+          document.documentElement.style.setProperty('--background', themeColors.background);
+          document.documentElement.style.setProperty('--foreground', themeColors.foreground);
+          document.documentElement.style.setProperty('--border', themeColors.border);
+          document.documentElement.style.setProperty('--card', themeColors.card);
+          document.documentElement.style.setProperty('--card-foreground', themeColors.cardForeground);
       } catch (e) {
         console.warn("Theme DOM update warning:", e);
       }

--- a/client/src/pages/ai-enhanced-dashboard.tsx
+++ b/client/src/pages/ai-enhanced-dashboard.tsx
@@ -481,13 +481,13 @@ function SmartLinkAI({ links, onApplySuggestions }: { links: Link[], onApplySugg
   };
   
   return (
-    <Card className="shadow-xl border-2 border-blue-200/50 bg-white/90 backdrop-blur-lg dark:bg-gray-900/90 dark:border-gray-600/50">
-      <CardHeader className="pb-2 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-gray-800/50 dark:to-gray-700/50 border-b border-blue-200/30 dark:border-gray-600/30">
-        <CardTitle className="flex items-center text-lg font-semibold text-slate-800 dark:text-gray-200">
+    <Card className="shadow-xl border-2 border-border/50 bg-card/90 backdrop-blur-lg">
+      <CardHeader className="pb-2 bg-gradient-to-r from-primary/10 to-secondary/10 border-b border-border/30">
+        <CardTitle className="flex items-center text-lg font-semibold text-foreground">
           <Brain className="h-5 w-5 mr-2 text-indigo-500" />
           Smart Link AI
         </CardTitle>
-        <CardDescription className="text-slate-600 dark:text-gray-400">
+        <CardDescription className="text-muted-foreground">
           Let AI analyze your engagement data and suggest the optimal order for your links
         </CardDescription>
       </CardHeader>
@@ -598,13 +598,13 @@ function PitchModeCard() {
   const [, navigate] = useLocation();
   
   return (
-    <Card id="pitch-mode" className="shadow-xl border-2 border-blue-200/50 bg-white/90 backdrop-blur-lg dark:bg-gray-900/90 dark:border-gray-600/50">
-      <CardHeader className="pb-4 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-gray-800/50 dark:to-gray-700/50 border-b border-blue-200/30 dark:border-gray-600/30">
+    <Card id="pitch-mode" className="shadow-xl border-2 border-border/50 bg-card/90 backdrop-blur-lg">
+      <CardHeader className="pb-4 bg-gradient-to-r from-primary/10 to-secondary/10 border-b border-border/30">
         <div className="flex items-center">
           <Presentation className="h-5 w-5 mr-2 text-blue-600" />
-          <CardTitle className="text-slate-800 dark:text-gray-200">Pitch Mode</CardTitle>
+          <CardTitle className="text-foreground">Pitch Mode</CardTitle>
         </div>
-        <CardDescription className="text-slate-600 dark:text-gray-400">
+        <CardDescription className="text-muted-foreground">
           Transform your profile for different audiences
         </CardDescription>
       </CardHeader>
@@ -612,7 +612,7 @@ function PitchModeCard() {
         <div className="space-y-4">
           <div className="text-center">
             <Presentation className="h-12 w-12 mx-auto mb-3 text-blue-500" />
-            <p className="text-sm text-slate-600 dark:text-gray-400 mb-4">
+            <p className="text-sm text-muted-foreground mb-4">
               Configure your pitch mode settings to optimize your profile for professional presentations, networking, and client meetings.
             </p>
           </div>
@@ -1468,7 +1468,7 @@ export default function AIEnhancedDashboard() {
       />
       
       {/* Dashboard Header */}
-      <header className="dashboard-header bg-white/90 dark:bg-gray-900/90 backdrop-blur-md border-b-2 border-blue-200 dark:border-gray-700 shadow-lg">
+      <header className="dashboard-header bg-background/90 backdrop-blur-md border-b-2 border-border/50 shadow-lg">
         <div className="container flex h-16 items-center justify-between px-4 md:px-6">
           <div className="flex items-center gap-4">
             <img 
@@ -1492,7 +1492,7 @@ export default function AIEnhancedDashboard() {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" className="relative">
-                  <Bell className="h-5 w-5 text-slate-600 dark:text-gray-400" />
+                  <Bell className="h-5 w-5 text-muted-foreground" />
                   {notifications && notifications.length > 0 && (
                     <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
                       {notifications.filter(n => n.status === 'pending').length}
@@ -1508,7 +1508,7 @@ export default function AIEnhancedDashboard() {
                     {notifications.map((notification: any) => (
                       <div 
                         key={notification.id} 
-                        className="p-3 border-b border-gray-100 last:border-b-0 cursor-pointer hover:bg-gray-50"
+                        className="p-3 border-b border-border last:border-b-0 cursor-pointer hover:bg-muted"
                         onClick={() => {
                           // Mark notification as read when clicked
                           markNotificationAsReadMutation.mutate(notification.id);
@@ -1539,8 +1539,8 @@ export default function AIEnhancedDashboard() {
                                 {notification.type.replace('_', ' ')}
                               </Badge>
                             </div>
-                            <p className="text-xs text-gray-600 mb-2">{notification.message}</p>
-                            <p className="text-xs text-gray-400">
+                            <p className="text-xs text-muted-foreground mb-2">{notification.message}</p>
+                            <p className="text-xs text-muted-foreground">
                               {new Date(notification.createdAt).toLocaleDateString()}
                             </p>
                           </div>
@@ -1601,7 +1601,7 @@ export default function AIEnhancedDashboard() {
                     ))}
                   </div>
                 ) : (
-                  <div className="p-4 text-center text-gray-500">
+                  <div className="p-4 text-center text-muted-foreground">
                     No notifications
                   </div>
                 )}
@@ -1642,7 +1642,7 @@ export default function AIEnhancedDashboard() {
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem 
-                  className="text-red-600 dark:text-red-400"
+                  className="text-destructive"
                   onClick={() => {
                     // Call the logout API
                     apiRequest("POST", "/api/logout")
@@ -1684,15 +1684,15 @@ export default function AIEnhancedDashboard() {
             <h1 className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-purple-600 mb-2">
               Welcome to Your Dashboard
             </h1>
-            <p className="text-slate-600 dark:text-gray-400 text-lg">
+            <p className="text-muted-foreground text-lg">
               Manage your profile, links, and view performance metrics
             </p>
           </div>
           {/* Enhanced Profile Preview - Matches Public Profile */}
-          <Card className="profile-preview-card overflow-hidden shadow-xl border-2 border-blue-200/50 bg-white/90 backdrop-blur-lg dark:bg-gray-800/90 dark:border-gray-600/50">
-            <CardHeader className="pb-4 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-gray-800/30 dark:to-gray-800/30 border-b border-blue-200/30 dark:border-gray-600/30">
+          <Card className="profile-preview-card overflow-hidden shadow-xl border-2 border-border/50 bg-card/90 backdrop-blur-lg">
+            <CardHeader className="pb-4 bg-gradient-to-r from-primary/10 to-secondary/10 border-b border-border/30">
               <div className="flex items-center justify-between">
-                <CardTitle className="flex items-center text-slate-800 dark:text-gray-200">
+                <CardTitle className="flex items-center text-foreground">
                   <User className="h-5 w-5 mr-2 text-blue-600" />
                   Profile Preview
                 </CardTitle>
@@ -1706,7 +1706,7 @@ export default function AIEnhancedDashboard() {
                   View Live
                 </Button>
               </div>
-              <CardDescription className="text-slate-600 dark:text-gray-400">How your public profile appears to visitors</CardDescription>
+              <CardDescription className="text-muted-foreground">How your public profile appears to visitors</CardDescription>
             </CardHeader>
             <CardContent className="p-0">
               {/* Hero Section - Exactly like public profile */}
@@ -1726,7 +1726,7 @@ export default function AIEnhancedDashboard() {
                 <div className="absolute bottom-0 left-0 right-0 p-4">
                   <div className="flex items-end gap-4">
                     {/* Profile Avatar - Same size as public */}
-                    <div className="w-16 h-16 md:w-20 md:h-20 rounded-full border-4 border-white overflow-hidden bg-white">
+                    <div className="w-16 h-16 md:w-20 md:h-20 rounded-full border-4 border-background overflow-hidden bg-background">
                       {userData?.profileImage ? (
                         <img 
                           src={userData.profileImage} 
@@ -1756,7 +1756,7 @@ export default function AIEnhancedDashboard() {
 
               {/* Welcome Message Section */}
               {userData?.welcomeMessage && (
-                <div className="p-4 border-b bg-gray-50/50">
+                <div className="p-4 border-b bg-muted/50">
                   <div className="flex items-center justify-center">
                     <Button 
                       variant="outline" 
@@ -1840,7 +1840,7 @@ export default function AIEnhancedDashboard() {
                     <div className="border rounded-md p-3 bg-muted/10">
                       <p className="text-xs font-medium mb-2">Profile QR Code</p>
                       <div className="flex justify-center mb-2">
-                        <div className="bg-white p-2 rounded shadow-sm" style={{ minHeight: '188px', minWidth: '188px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <div className="bg-card p-2 rounded shadow-sm" style={{ minHeight: '188px', minWidth: '188px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                           {isGeneratingQRCode ? (
                             <div className="flex flex-col items-center justify-center">
                               <RefreshCw className="h-8 w-8 text-primary animate-spin mb-2" />
@@ -1921,17 +1921,17 @@ export default function AIEnhancedDashboard() {
           </Card>
           
           {/* Quick Actions Card - Moved right after Profile Preview */}
-          <Card className="shadow-xl border-2 border-blue-200/50 bg-white/90 backdrop-blur-lg dark:bg-gray-800/90 dark:border-gray-600/50">
-            <CardHeader className="pb-4 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-gray-800/30 dark:to-gray-800/30 border-b border-blue-200/30 dark:border-gray-600/30">
-              <CardTitle className="text-slate-800 dark:text-gray-200 dark:text-gray-200">Quick Actions</CardTitle>
-              <CardDescription className="text-slate-600 dark:text-gray-400 dark:text-gray-400">Frequently used tools</CardDescription>
+          <Card className="shadow-xl border-2 border-border/50 bg-card/90 backdrop-blur-lg">
+            <CardHeader className="pb-4 bg-gradient-to-r from-primary/10 to-secondary/10 border-b border-border/30">
+              <CardTitle className="text-foreground">Quick Actions</CardTitle>
+              <CardDescription className="text-muted-foreground">Frequently used tools</CardDescription>
             </CardHeader>
             <CardContent className="pt-0">
               <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                 <Button 
                   variant="outline" 
                   size="sm" 
-                  className="flex flex-col h-auto py-3 text-center justify-center bg-white/80 dark:bg-gray-700/30"
+                  className="flex flex-col h-auto py-3 text-center justify-center bg-card/80"
                   onClick={() => navigate("/optimize-links")}
                 >
                   <Shuffle className="h-4 w-4 mb-1 text-indigo-500" />
@@ -1940,7 +1940,7 @@ export default function AIEnhancedDashboard() {
                 <Button 
                   variant="outline" 
                   size="sm" 
-                  className="flex flex-col h-auto py-3 text-center justify-center bg-white/80 dark:bg-gray-700/30"
+                  className="flex flex-col h-auto py-3 text-center justify-center bg-card/80"
                   onClick={() => navigate("/spotlight")}
                 >
                   <Presentation className="h-4 w-4 mb-1 text-indigo-500" />
@@ -1949,7 +1949,7 @@ export default function AIEnhancedDashboard() {
                 <Button 
                   variant="outline" 
                   size="sm" 
-                  className="flex flex-col h-auto py-3 text-center justify-center bg-white/80 dark:bg-gray-700/30"
+                  className="flex flex-col h-auto py-3 text-center justify-center bg-card/80"
                   onClick={() => navigate("/collaboration")}
                 >
                   <Users className="h-4 w-4 mb-1 text-indigo-500" />
@@ -1958,7 +1958,7 @@ export default function AIEnhancedDashboard() {
                 <Button 
                   variant="outline" 
                   size="sm" 
-                  className="flex flex-col h-auto py-3 text-center justify-center bg-white/80 dark:bg-gray-700/30"
+                  className="flex flex-col h-auto py-3 text-center justify-center bg-card/80"
                   onClick={() => navigate("/industry-examples")}
                 >
                   <Briefcase className="h-4 w-4 mb-1 text-indigo-500" />
@@ -1967,7 +1967,7 @@ export default function AIEnhancedDashboard() {
                 <Button 
                   variant="outline" 
                   size="sm" 
-                  className="flex flex-col h-auto py-3 text-center justify-center bg-white/80 dark:bg-gray-700/30"
+                  className="flex flex-col h-auto py-3 text-center justify-center bg-card/80"
                   onClick={() => navigate("/referral-links")}
                 >
                   <Share2 className="h-4 w-4 mb-1 text-indigo-500" />
@@ -1976,7 +1976,7 @@ export default function AIEnhancedDashboard() {
                 <Button 
                   variant="outline" 
                   size="sm" 
-                  className="flex flex-col h-auto py-3 text-center justify-center bg-white/80 dark:bg-gray-700/30"
+                  className="flex flex-col h-auto py-3 text-center justify-center bg-card/80"
                   onClick={() => navigate("/branding")}
                 >
                   <Paintbrush className="h-4 w-4 mb-1 text-indigo-500" />
@@ -1985,7 +1985,7 @@ export default function AIEnhancedDashboard() {
                 <Button 
                   variant="outline" 
                   size="sm" 
-                  className="flex flex-col h-auto py-3 text-center justify-center bg-white/80 dark:bg-gray-700/30"
+                  className="flex flex-col h-auto py-3 text-center justify-center bg-card/80"
                   onClick={() => navigate("/themes-demo")}
                 >
                   <Palette className="h-4 w-4 mb-1 text-indigo-500" />
@@ -1994,7 +1994,7 @@ export default function AIEnhancedDashboard() {
                 <Button 
                   variant="outline" 
                   size="sm" 
-                  className="flex flex-col h-auto py-3 text-center justify-center bg-white/80 dark:bg-gray-700/30"
+                  className="flex flex-col h-auto py-3 text-center justify-center bg-card/80"
                   onClick={() => navigate("/my-links")}
                 >
                   <LinkIcon className="h-4 w-4 mb-1 text-indigo-500" />
@@ -2007,17 +2007,17 @@ export default function AIEnhancedDashboard() {
           {/* Three Analysis Cards in a Row */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Social Score Card */}
-            <Card className="shadow-xl border-2 border-blue-200/50 bg-white/90 backdrop-blur-lg dark:bg-gray-900/90 dark:border-gray-600/50">
-              <CardHeader className="pb-4 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-gray-800/50 dark:to-gray-700/50 border-b border-blue-200/30 dark:border-gray-600/30">
-                <CardTitle className="text-slate-800 dark:text-gray-200 text-lg">Social Score</CardTitle>
-                <CardDescription className="text-slate-600 dark:text-gray-400">Your profile engagement rating</CardDescription>
+            <Card className="shadow-xl border-2 border-border/50 bg-card/90 backdrop-blur-lg">
+              <CardHeader className="pb-4 bg-gradient-to-r from-primary/10 to-secondary/10 border-b border-border/30">
+                <CardTitle className="text-foreground text-lg">Social Score</CardTitle>
+                <CardDescription className="text-muted-foreground">Your profile engagement rating</CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="text-center">
                   <div className="text-4xl font-bold text-blue-600 mb-2">
                     {isLoadingStats ? "..." : `${stats?.score || 0}%`}
                   </div>
-                  <div className="text-sm text-slate-600 dark:text-gray-400 mb-4">
+                  <div className="text-sm text-muted-foreground mb-4">
                     {isLoadingStats ? "Loading..." : "Social engagement score"}
                   </div>
                   {!isLoadingStats && (
@@ -2040,17 +2040,17 @@ export default function AIEnhancedDashboard() {
             </Card>
 
             {/* Profile Views Card */}
-            <Card className="shadow-xl border-2 border-blue-200/50 bg-white/90 backdrop-blur-lg dark:bg-gray-900/90 dark:border-gray-600/50">
-              <CardHeader className="pb-4 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-gray-800/50 dark:to-gray-700/50 border-b border-blue-200/30 dark:border-gray-600/30">
-                <CardTitle className="text-slate-800 dark:text-gray-200 text-lg">Profile Views</CardTitle>
-                <CardDescription className="text-slate-600 dark:text-gray-400">Total profile visits</CardDescription>
+            <Card className="shadow-xl border-2 border-border/50 bg-card/90 backdrop-blur-lg">
+              <CardHeader className="pb-4 bg-gradient-to-r from-primary/10 to-secondary/10 border-b border-border/30">
+                <CardTitle className="text-foreground text-lg">Profile Views</CardTitle>
+                <CardDescription className="text-muted-foreground">Total profile visits</CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="text-center">
                   <div className="text-4xl font-bold text-green-600 mb-2">
                     {isLoadingStats ? "..." : stats?.profileViews || 0}
                   </div>
-                  <div className="text-sm text-slate-600 dark:text-gray-400 mb-4">
+                  <div className="text-sm text-muted-foreground mb-4">
                     {isLoadingStats ? "Loading..." : "Total visits"}
                   </div>
                   <div className="flex items-center justify-center gap-1 text-sm text-green-600">
@@ -2062,17 +2062,17 @@ export default function AIEnhancedDashboard() {
             </Card>
 
             {/* Link Clicks Card */}
-            <Card className="shadow-xl border-2 border-blue-200/50 bg-white/90 backdrop-blur-lg dark:bg-gray-900/90 dark:border-gray-600/50">
-              <CardHeader className="pb-4 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-gray-800/50 dark:to-gray-700/50 border-b border-blue-200/30 dark:border-gray-600/30">
-                <CardTitle className="text-slate-800 dark:text-gray-200 text-lg">Link Clicks</CardTitle>
-                <CardDescription className="text-slate-600 dark:text-gray-400">Total link interactions</CardDescription>
+            <Card className="shadow-xl border-2 border-border/50 bg-card/90 backdrop-blur-lg">
+              <CardHeader className="pb-4 bg-gradient-to-r from-primary/10 to-secondary/10 border-b border-border/30">
+                <CardTitle className="text-foreground text-lg">Link Clicks</CardTitle>
+                <CardDescription className="text-muted-foreground">Total link interactions</CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="text-center">
                   <div className="text-4xl font-bold text-purple-600 mb-2">
                     {isLoadingStats ? "..." : stats?.linkClicks || 0}
                   </div>
-                  <div className="text-sm text-slate-600 dark:text-gray-400 mb-4">
+                  <div className="text-sm text-muted-foreground mb-4">
                     {isLoadingStats ? "Loading..." : "Total clicks"}
                   </div>
                   <div className="flex items-center justify-center gap-1 text-sm text-purple-600">
@@ -2086,11 +2086,11 @@ export default function AIEnhancedDashboard() {
 
           {/* Multi-Platform Content Preview - NEW FEATURE SECTION */}
           {FEATURE_CONTENT_PREVIEW && (
-            <Card className="mb-6 bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-gray-800/40 dark:to-gray-700/40 border-2 border-indigo-200 dark:border-gray-600 shadow-lg">
+            <Card className="mb-6 bg-gradient-to-r from-primary/5 to-secondary/5 border-2 border-border/50 shadow-lg">
             <CardHeader>
               <div className="flex items-center justify-between">
                 <div>
-                  <CardTitle className="flex items-center gap-3 text-xl text-indigo-600 dark:text-indigo-400">
+                  <CardTitle className="flex items-center gap-3 text-xl text-primary">
                     <Eye className="h-7 w-7" />
                     Content Preview
                     <Badge variant="secondary" className="bg-indigo-100 text-indigo-700 border-indigo-300">NEW</Badge>
@@ -2112,7 +2112,7 @@ export default function AIEnhancedDashboard() {
                   {isLoadingInstagram ? (
                     <div className="p-4 border-2 border-dashed border-pink-300 rounded-lg text-center min-h-[180px] flex flex-col justify-center">
                       <div className="animate-spin rounded-full h-8 w-8 border-2 border-pink-500 border-t-transparent mx-auto mb-2"></div>
-                      <p className="text-xs text-gray-600">Loading...</p>
+                      <p className="text-xs text-muted-foreground">Loading...</p>
                     </div>
                   ) : instagramPreview?.connected && instagramPreview?.latestPost ? (
                     <div className="border-2 border-pink-300 rounded-lg overflow-hidden min-h-[180px]">
@@ -2137,7 +2137,7 @@ export default function AIEnhancedDashboard() {
                           <span className="text-xs font-medium">@{instagramPreview.profile?.username}</span>
                         </div>
                         {instagramPreview.latestPost.caption && (
-                          <p className="text-xs text-gray-600 dark:text-gray-400 line-clamp-2 mb-2">
+                          <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
                             {instagramPreview.latestPost.caption.length > 80 
                               ? `${instagramPreview.latestPost.caption.substring(0, 80)}...` 
                               : instagramPreview.latestPost.caption}
@@ -2157,7 +2157,7 @@ export default function AIEnhancedDashboard() {
                     <div className="p-4 border-2 border-dashed border-pink-300 rounded-lg text-center min-h-[180px] flex flex-col justify-center">
                       <Instagram className="h-8 w-8 mx-auto text-pink-400 mb-2" />
                       <h4 className="font-medium text-sm mb-1">Instagram Connected</h4>
-                      <p className="text-xs text-gray-600 dark:text-gray-400 mb-3">
+                      <p className="text-xs text-muted-foreground mb-3">
                         Showcasing your latest post
                       </p>
                       <Button 
@@ -2178,12 +2178,12 @@ export default function AIEnhancedDashboard() {
                     Facebook
                   </h3>
                   {isLoadingFacebook ? (
-                    <div className="p-4 border-2 border-dashed border-blue-300 rounded-lg text-center min-h-[180px] flex flex-col justify-center">
-                      <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-500 border-t-transparent mx-auto mb-2"></div>
-                      <p className="text-xs text-gray-600">Loading...</p>
+                    <div className="p-4 border-2 border-dashed border-border rounded-lg text-center min-h-[180px] flex flex-col justify-center">
+                      <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent mx-auto mb-2"></div>
+                      <p className="text-xs text-muted-foreground">Loading...</p>
                     </div>
                   ) : facebookPreview?.connected && facebookPreview?.latestPost ? (
-                    <div className="border-2 border-blue-300 rounded-lg overflow-hidden min-h-[180px]">
+                    <div className="border-2 border-border rounded-lg overflow-hidden min-h-[180px]">
                       <div className="relative">
                         {facebookPreview.latestPost.mediaUrl ? (
                           <img 
@@ -2211,7 +2211,7 @@ export default function AIEnhancedDashboard() {
                           <span className="text-xs font-medium">@{facebookPreview.profile?.username}</span>
                         </div>
                         {facebookPreview.latestPost.caption && (
-                          <p className="text-xs text-gray-600 dark:text-gray-400 line-clamp-2 mb-2">
+                          <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
                             {facebookPreview.latestPost.caption.length > 80 
                               ? `${facebookPreview.latestPost.caption.substring(0, 80)}...` 
                               : facebookPreview.latestPost.caption}
@@ -2228,12 +2228,12 @@ export default function AIEnhancedDashboard() {
                       </div>
                     </div>
                   ) : (
-                    <div className="p-4 border-2 border-dashed border-blue-300 rounded-lg text-center min-h-[180px] flex flex-col justify-center">
+                    <div className="p-4 border-2 border-dashed border-border rounded-lg text-center min-h-[180px] flex flex-col justify-center">
                       <Facebook className="h-8 w-8 mx-auto text-blue-500 mb-2" />
                       <h4 className="font-medium text-sm mb-1">
                         {facebookPreview?.tokenExpired ? 'Token Expired' : 'Not Connected'}
                       </h4>
-                      <p className="text-xs text-gray-600 dark:text-gray-400 mb-3">
+                      <p className="text-xs text-muted-foreground mb-3">
                         {facebookPreview?.message || 'Show your latest post'}
                       </p>
                       <Button 
@@ -2256,12 +2256,12 @@ export default function AIEnhancedDashboard() {
                     TikTok
                   </h3>
                   {isLoadingTikTok ? (
-                    <div className="p-4 border-2 border-dashed border-gray-400 rounded-lg text-center min-h-[180px] flex flex-col justify-center">
-                      <div className="animate-spin rounded-full h-8 w-8 border-2 border-gray-500 border-t-transparent mx-auto mb-2"></div>
-                      <p className="text-xs text-gray-600">Loading...</p>
+                    <div className="p-4 border-2 border-dashed border-border rounded-lg text-center min-h-[180px] flex flex-col justify-center">
+                      <div className="animate-spin rounded-full h-8 w-8 border-2 border-border border-t-transparent mx-auto mb-2"></div>
+                      <p className="text-xs text-muted-foreground">Loading...</p>
                     </div>
                   ) : tiktokPreview?.connected && tiktokPreview?.latestPost ? (
-                    <div className="border-2 border-gray-400 rounded-lg overflow-hidden min-h-[180px]">
+                    <div className="border-2 border-border rounded-lg overflow-hidden min-h-[180px]">
                       <div className="relative">
                         {tiktokPreview.latestPost.thumbnailUrl ? (
                           <img 
@@ -2271,7 +2271,7 @@ export default function AIEnhancedDashboard() {
                             onClick={() => window.open(tiktokPreview.latestPost.permalink, '_blank')}
                           />
                         ) : (
-                          <div className="w-full h-32 bg-gray-100 flex items-center justify-center">
+                          <div className="w-full h-32 bg-muted flex items-center justify-center">
                             <div className="h-12 w-12 bg-black rounded-sm flex items-center justify-center text-white text-lg font-bold">T</div>
                           </div>
                         )}
@@ -2287,7 +2287,7 @@ export default function AIEnhancedDashboard() {
                           <span className="text-xs font-medium">@{tiktokPreview.profile?.username}</span>
                         </div>
                         {tiktokPreview.latestPost.caption && (
-                          <p className="text-xs text-gray-600 dark:text-gray-400 line-clamp-2 mb-2">
+                          <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
                             {tiktokPreview.latestPost.caption.length > 80 
                               ? `${tiktokPreview.latestPost.caption.substring(0, 80)}...` 
                               : tiktokPreview.latestPost.caption}
@@ -2304,17 +2304,17 @@ export default function AIEnhancedDashboard() {
                       </div>
                     </div>
                   ) : (
-                    <div className="p-4 border-2 border-dashed border-gray-400 rounded-lg text-center min-h-[180px] flex flex-col justify-center">
+                    <div className="p-4 border-2 border-dashed border-border rounded-lg text-center min-h-[180px] flex flex-col justify-center">
                       <div className="h-8 w-8 mx-auto bg-black rounded-sm flex items-center justify-center text-white text-sm font-bold mb-2">T</div>
                       <h4 className="font-medium text-sm mb-1">
                         {tiktokPreview?.tokenExpired ? 'Token Expired' : 'Not Connected'}
                       </h4>
-                      <p className="text-xs text-gray-600 dark:text-gray-400 mb-3">
+                      <p className="text-xs text-muted-foreground mb-3">
                         {tiktokPreview?.message || 'Show your latest video'}
                       </p>
                       <Button 
                         size="sm" 
-                        className="bg-black hover:bg-gray-800 text-white text-xs"
+                        className="bg-black hover:bg-muted text-white text-xs"
                         onClick={() => {
                           window.location.href = '/api/social/connect/tiktok';
                         }}
@@ -2332,12 +2332,12 @@ export default function AIEnhancedDashboard() {
                     X (Twitter)
                   </h3>
                   {isLoadingTwitter ? (
-                    <div className="p-4 border-2 border-dashed border-blue-300 rounded-lg text-center min-h-[180px] flex flex-col justify-center">
-                      <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-400 border-t-transparent mx-auto mb-2"></div>
-                      <p className="text-xs text-gray-600">Loading...</p>
+                    <div className="p-4 border-2 border-dashed border-border rounded-lg text-center min-h-[180px] flex flex-col justify-center">
+                      <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent mx-auto mb-2"></div>
+                      <p className="text-xs text-muted-foreground">Loading...</p>
                     </div>
                   ) : twitterPreview?.connected ? (
-                    <div className="border-2 border-blue-300 rounded-lg overflow-hidden min-h-[180px]">
+                    <div className="border-2 border-border rounded-lg overflow-hidden min-h-[180px]">
                       {twitterPreview.latestPost ? (
                         <>
                           <div className="relative">
@@ -2367,7 +2367,7 @@ export default function AIEnhancedDashboard() {
                               <span className="text-xs font-medium">@{twitterPreview.profile?.username}</span>
                             </div>
                             {twitterPreview.latestPost.caption && (
-                              <p className="text-xs text-gray-600 dark:text-gray-400 line-clamp-2 mb-2">
+                              <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
                                 {twitterPreview.latestPost.caption.length > 80 
                                   ? `${twitterPreview.latestPost.caption.substring(0, 80)}...` 
                                   : twitterPreview.latestPost.caption}
@@ -2392,7 +2392,7 @@ export default function AIEnhancedDashboard() {
                             <div className="w-2 h-2 bg-green-500 rounded-full"></div>
                             <span className="text-sm font-medium text-green-700">Connected</span>
                           </div>
-                          <p className="text-xs text-gray-600 dark:text-gray-400 text-center mb-3">
+                          <p className="text-xs text-muted-foreground text-center mb-3">
                             X account connected successfully. Posts will appear here when API access is enhanced.
                           </p>
                           <Button 
@@ -2407,12 +2407,12 @@ export default function AIEnhancedDashboard() {
                       )}
                     </div>
                   ) : (
-                    <div className="p-4 border-2 border-dashed border-blue-300 rounded-lg text-center min-h-[180px] flex flex-col justify-center">
+                    <div className="p-4 border-2 border-dashed border-border rounded-lg text-center min-h-[180px] flex flex-col justify-center">
                       <Twitter className="h-8 w-8 mx-auto text-blue-400 mb-2" />
                       <h4 className="font-medium text-sm mb-1">
                         {twitterPreview?.tokenExpired ? 'Token Expired' : 'Not Connected'}
                       </h4>
-                      <p className="text-xs text-gray-600 dark:text-gray-400 mb-3">
+                      <p className="text-xs text-muted-foreground mb-3">
                         {twitterPreview?.message || 'Show your latest tweet'}
                       </p>
                       <Button 
@@ -2447,13 +2447,13 @@ export default function AIEnhancedDashboard() {
             {/* Left Column - Engagement Trends (2 columns) */}
             <div className="md:col-span-2 space-y-6 overflow-x-hidden">
               {/* Engagement Trends Card */}
-              <Card className="shadow-xl border-2 border-blue-200/50 bg-white/90 backdrop-blur-lg dark:bg-gray-900/90 dark:border-gray-600/50">
-                <CardHeader className="bg-gradient-to-r from-blue-100 to-purple-100 dark:from-gray-800/50 dark:to-gray-700/50 border-b border-blue-200/30 dark:border-gray-600/30">
-                  <CardTitle className="flex items-center text-slate-800 dark:text-gray-200">
+              <Card className="shadow-xl border-2 border-border/50 bg-card/90 backdrop-blur-lg">
+              <CardHeader className="bg-gradient-to-r from-primary/10 to-secondary/10 border-b border-border/30">
+                  <CardTitle className="flex items-center text-foreground">
                     <LineChart className="h-5 w-5 mr-2 text-blue-600" />
                     Engagement Trends
                   </CardTitle>
-                  <CardDescription className="text-slate-600 dark:text-gray-400">View your profile performance over time</CardDescription>
+                  <CardDescription className="text-muted-foreground">View your profile performance over time</CardDescription>
                 </CardHeader>
                 <CardContent>
                   <div className="h-[200px]">
@@ -2639,13 +2639,13 @@ export default function AIEnhancedDashboard() {
                 </audio>
               </div>
             ) : userData?.welcomeMessage ? (
-              <div className="p-4 bg-gray-50 rounded-lg border">
-                <p className="text-gray-700 leading-relaxed">
+              <div className="p-4 bg-card rounded-lg border">
+                <p className="text-foreground leading-relaxed">
                   {userData.welcomeMessage}
                 </p>
               </div>
             ) : (
-              <div className="p-4 text-center text-gray-500">
+              <div className="p-4 text-center text-muted-foreground">
                 No welcome message available
               </div>
             )}

--- a/client/src/pages/public-profile.tsx
+++ b/client/src/pages/public-profile.tsx
@@ -119,7 +119,7 @@ export default function PublicProfile() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
           <p className="text-muted-foreground">Loading profile...</p>
@@ -130,7 +130,7 @@ export default function PublicProfile() {
 
   if (error || !data) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-2xl font-bold mb-4">Profile Not Found</h1>
           <p className="text-muted-foreground mb-6">The profile you're looking for doesn't exist.</p>
@@ -180,7 +180,7 @@ export default function PublicProfile() {
   const themeStyles = getThemeStyles();
 
   return (
-    <div className={`min-h-screen ${profile.darkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
+    <div className="min-h-screen bg-background">
       {/* Top Navigation */}
       <div className="absolute top-0 left-0 right-0 z-10 p-4">
         <div className="flex justify-between items-center">
@@ -193,7 +193,7 @@ export default function PublicProfile() {
           <Button
             variant="ghost"
             size="sm"
-            className="text-white hover:bg-white/20"
+            className="text-foreground hover:bg-accent/20"
             onClick={() => window.location.href = '/'}
           >
             Create Your Profile
@@ -219,7 +219,7 @@ export default function PublicProfile() {
           <div className="max-w-4xl mx-auto">
             <div className="flex items-end gap-3 sm:gap-6">
               {/* Profile Avatar */}
-              <div className="w-20 h-20 sm:w-24 sm:h-24 md:w-32 md:h-32 rounded-full border-4 border-white bg-white overflow-hidden flex-shrink-0">
+              <div className="w-20 h-20 sm:w-24 sm:h-24 md:w-32 md:h-32 rounded-full border-4 border-background bg-background overflow-hidden flex-shrink-0">
                 {profile.profileImage ? (
                   <img 
                     src={profile.profileImage} 
@@ -234,9 +234,9 @@ export default function PublicProfile() {
               </div>
               
               {/* Profile Info */}
-              <div className="text-white flex-1 min-w-0">
+              <div className="text-foreground flex-1 min-w-0">
                 <h1 className="text-xl sm:text-2xl md:text-4xl font-bold mb-2 truncate">{profile.name}</h1>
-                <p className="text-gray-200 text-sm md:text-base mb-2 break-words leading-relaxed max-w-full overflow-hidden">
+                <p className="text-muted-foreground text-sm md:text-base mb-2 break-words leading-relaxed max-w-full overflow-hidden">
                   {profile.bio && profile.bio.length > 160 ? `${profile.bio.substring(0, 160)}...` : profile.bio}
                 </p>
                 <div className="flex flex-wrap gap-2 sm:gap-4 text-sm">
@@ -272,7 +272,7 @@ export default function PublicProfile() {
           <div className="lg:col-span-2 space-y-6">
             {/* Welcome Message */}
             {profile.welcomeMessage && (
-              <Card className={profile.darkMode ? 'bg-gray-800 border-gray-700' : ''}>
+              <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <MessageCircle className="h-5 w-5" />
@@ -307,7 +307,7 @@ export default function PublicProfile() {
                       Your browser does not support the video element.
                     </video>
                   ) : (
-                    <p className={`${profile.darkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                    <p className="text-foreground">
                       {profile.welcomeMessage}
                     </p>
                   )}
@@ -317,7 +317,7 @@ export default function PublicProfile() {
 
             {/* Links Section */}
             {links && links.length > 0 && (
-              <Card className={profile.darkMode ? 'bg-gray-800 border-gray-700' : ''}>
+              <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Globe className="h-5 w-5" />
@@ -334,9 +334,7 @@ export default function PublicProfile() {
                         <Button
                           key={link.id}
                           variant="outline"
-                          className={`justify-start p-4 h-auto hover:scale-105 transition-all ${
-                            profile.darkMode ? 'bg-gray-700 border-gray-600 hover:bg-gray-600' : 'bg-white hover:bg-gray-50'
-                          }`}
+                          className="justify-start p-4 h-auto hover:scale-105 transition-all bg-card border-border hover:bg-accent"
                           onClick={() => handleLinkClick(link.id, link.url)}
                         >
                           <div className="flex items-center gap-3 w-full">
@@ -367,7 +365,7 @@ export default function PublicProfile() {
 
             {/* Collaborative Spotlight */}
             {spotlightProjects && spotlightProjects.length > 0 && (
-              <Card className={profile.darkMode ? 'bg-gray-800 border-gray-700' : ''}>
+              <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <GitBranch className="h-5 w-5" />
@@ -377,7 +375,7 @@ export default function PublicProfile() {
                 <CardContent>
                   <div className="grid gap-4">
                     {spotlightProjects.map(project => (
-                      <div key={project.id} className={`p-4 rounded-lg border ${profile.darkMode ? 'bg-gray-700 border-gray-600' : 'bg-gray-50 border-gray-200'}`}>
+                      <div key={project.id} className="p-4 rounded-lg border bg-card border-border">
                         <div className="flex items-start gap-4">
                           {project.imageUrl && (
                             <img 
@@ -396,7 +394,7 @@ export default function PublicProfile() {
                                 </Badge>
                               )}
                             </div>
-                            <p className={`text-sm mb-3 ${profile.darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                            <p className="text-sm mb-3 text-foreground">
                               {project.description}
                             </p>
                             <div className="flex items-center justify-between">
@@ -431,7 +429,7 @@ export default function PublicProfile() {
           <div className="space-y-6">
             {/* Skills & Industry */}
             {(profile.skills?.length || profile.industry) && (
-              <Card className={profile.darkMode ? 'bg-gray-800 border-gray-700' : ''}>
+              <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Award className="h-5 w-5" />
@@ -463,7 +461,7 @@ export default function PublicProfile() {
 
             {/* Referral Links */}
             {referralLinks && referralLinks.length > 0 && (
-              <Card className={profile.darkMode ? 'bg-gray-800 border-gray-700' : ''}>
+              <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Star className="h-5 w-5" />
@@ -473,12 +471,12 @@ export default function PublicProfile() {
                 <CardContent>
                   <div className="space-y-3">
                     {referralLinks.map(link => (
-                      <div key={link.id} className={`p-3 rounded-lg border ${profile.darkMode ? 'bg-gray-700 border-gray-600' : 'bg-gray-50 border-gray-200'}`}>
+                      <div key={link.id} className="p-3 rounded-lg border bg-card border-border">
                         <div className="flex items-center justify-between">
                           <div className="flex-1">
                             <h4 className="font-medium text-sm">{link.title}</h4>
                             {link.description && (
-                              <p className={`text-xs mt-1 ${profile.darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                              <p className="text-xs mt-1 text-muted-foreground">
                                 {link.description}
                               </p>
                             )}


### PR DESCRIPTION
## Summary
- ensure theme config defines card colors
- style headers, cards, and sections with theme-aware classes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab1124165c832c973aaa1440754545