### PR TITLE
Fix theme colors for action buttons on dashboard and profile pages

### DIFF
--- a/client/src/pages/ai-enhanced-dashboard.tsx
+++ b/client/src/pages/ai-enhanced-dashboard.tsx
@@ -617,9 +617,9 @@ function PitchModeCard() {
             </p>
           </div>
           
-          <Button 
+          <Button
             onClick={() => navigate("/settings?tab=pitch-mode")}
-            className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white"
+            className="w-full bg-gradient-to-r from-[hsl(var(--primary))] to-[hsl(var(--secondary))] hover:opacity-90 text-primary-foreground"
           >
             <Settings className="h-4 w-4 mr-2" />
             Configure Pitch Mode
@@ -2028,9 +2028,9 @@ export default function AIEnhancedDashboard() {
                       ></div>
                     </div>
                   )}
-                  <Button 
+                  <Button
                     size="sm"
-                    className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white"
+                    className="w-full bg-gradient-to-r from-[hsl(var(--primary))] to-[hsl(var(--secondary))] hover:opacity-90 text-primary-foreground"
                     onClick={() => navigate("/social-score")}
                   >
                     View Details

--- a/client/src/pages/visitor-profile-new.tsx
+++ b/client/src/pages/visitor-profile-new.tsx
@@ -996,8 +996,8 @@ export default function VisitorProfileNew() {
 
               <Dialog open={showReferralDialog} onOpenChange={setShowReferralDialog}>
                 <DialogTrigger asChild>
-                  <Button 
-                    className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white"
+                  <Button
+                    className="w-full bg-gradient-to-r from-[hsl(var(--primary))] to-[hsl(var(--secondary))] hover:opacity-90 text-primary-foreground"
                   >
                     <Plus className="h-4 w-4 mr-2" />
                     Request to Add My Link
@@ -1183,7 +1183,7 @@ export default function VisitorProfileNew() {
                 {/* Collaboration Request Button */}
                 <Dialog open={showCollaborationDialog} onOpenChange={setShowCollaborationDialog}>
                   <DialogTrigger asChild>
-                    <Button className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white">
+                    <Button className="w-full bg-gradient-to-r from-[hsl(var(--primary))] to-[hsl(var(--secondary))] hover:opacity-90 text-primary-foreground">
                       <Send className="h-4 w-4 mr-2" />
                       {currentUser ? 'Send Collaboration Request' : 'Login to Collaborate'}
                     </Button>


### PR DESCRIPTION
## Summary
- apply theme-aware gradient styling to Social Score and Pitch Mode buttons on dashboard
- update referral link and collaboration request buttons to use theme variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68abf300652c832cb6050d5a5c8124a3