### PR TITLE
Remove theme preview controls

### DIFF
--- a/client/src/pages/simple-themes-demo.tsx
+++ b/client/src/pages/simple-themes-demo.tsx
@@ -13,7 +13,6 @@ import {
   Waves, 
   Crown,
   Check,
-  Eye,
   Save,
   ArrowLeft
 } from "lucide-react";
@@ -137,7 +136,6 @@ export default function SimpleThemesDemo() {
   const { toast } = useToast();
   const [, navigate] = useLocation();
   const { user } = useAuth();
-  const [selectedTheme, setSelectedTheme] = useState<Theme>(presetThemes[0]);
   const getStoredTheme = () => {
     if (typeof window !== 'undefined') {
       return localStorage.getItem('theme') || 'ocean';
@@ -347,45 +345,18 @@ export default function SimpleThemesDemo() {
             <CardContent className="space-y-4">
               <PreviewCard theme={theme} />
               
-              <div className="flex space-x-2">
-                <Button 
-                  variant="outline" 
-                  size="sm"
-                  onClick={() => setSelectedTheme(theme)}
-                >
-                  <Eye className="h-4 w-4 mr-1" />
-                  Preview
-                </Button>
-                
-                <Button 
-                  size="sm"
-                  onClick={() => handleApplyTheme(theme)}
-                  disabled={activeTheme === theme.id}
-                >
-                  <Save className="h-4 w-4 mr-1" />
-                  {activeTheme === theme.id ? "Applied" : "Apply"}
-                </Button>
-              </div>
+              <Button
+                size="sm"
+                onClick={() => handleApplyTheme(theme)}
+                disabled={activeTheme === theme.id}
+              >
+                <Save className="h-4 w-4 mr-1" />
+                {activeTheme === theme.id ? "Applied" : "Apply"}
+              </Button>
             </CardContent>
           </Card>
         ))}
       </div>
-
-      {/* Large Preview Section */}
-      <Card className="mt-8">
-        <CardHeader>
-          <CardTitle>Theme Preview: {selectedTheme.name}</CardTitle>
-          <CardDescription>
-            See how your profile will look with the {selectedTheme.name} theme
-          </CardDescription>
-        </CardHeader>
-        
-        <CardContent>
-          <div className="max-w-md mx-auto">
-            <PreviewCard theme={selectedTheme} />
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/client/src/pages/themes-page.tsx
+++ b/client/src/pages/themes-page.tsx
@@ -20,7 +20,6 @@ import {
   Zap,
   Crown,
   Check,
-  Eye,
   Save
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
@@ -138,7 +137,6 @@ const presetThemes: Theme[] = [
 
 export default function ThemesPage() {
   const { user } = useAuth();
-  const [selectedTheme, setSelectedTheme] = useState<Theme>(presetThemes[0]);
   const applyTheme = useApplyTheme();
   const [customColors, setCustomColors] = useState({
     primary: "#3b82f6",
@@ -276,26 +274,14 @@ export default function ThemesPage() {
                 
                 <CardContent className="space-y-4">
                   <PreviewCard theme={theme} />
-                  
-                  <div className="flex space-x-2">
-                    <Button 
-                      variant="outline" 
-                      size="sm"
-                      onClick={() => setSelectedTheme(theme)}
-                    >
-                      <Eye className="h-4 w-4 mr-1" />
-                      Preview
-                    </Button>
-                    
-                    <Button 
-                      size="sm"
-                      onClick={() => handleSaveTheme(theme)}
-                      disabled={applyTheme.isPending}
-                    >
-                      <Save className="h-4 w-4 mr-1" />
-                      Apply
-                    </Button>
-                  </div>
+                  <Button
+                    size="sm"
+                    onClick={() => handleSaveTheme(theme)}
+                    disabled={applyTheme.isPending}
+                  >
+                    <Save className="h-4 w-4 mr-1" />
+                    Apply
+                  </Button>
                 </CardContent>
               </Card>
             ))}


### PR DESCRIPTION
## Summary
- remove preview buttons from theme cards
- drop theme preview section from theme demo page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abfdafaaec832c9ce97325a0526518