### PR TITLE
feat: enhance link forms for email and telegram

### DIFF
--- a/client/src/lib/link-utils.ts
+++ b/client/src/lib/link-utils.ts
@@ -5,6 +5,15 @@ export function formatLinkUrl(platform: string, url: string): string {
   if (platform === "whatsapp") {
     return `https://wa.me/${url.replace(/[^\d+]/g, "")}`;
   }
+  if (platform === "email") {
+    return `mailto:${url.replace(/^mailto:/i, "")}`;
+  }
+  if (platform === "telegram") {
+    const username = url
+      .replace(/^https?:\/\/t\.me\//i, "")
+      .replace(/^@/, "");
+    return `https://t.me/${username}`;
+  }
   if (!/^https?:\/\//i.test(url)) {
     return `https://${url}`;
   }
@@ -17,6 +26,12 @@ export function stripLinkUrl(platform: string, url: string): string {
   }
   if (platform === "whatsapp") {
     return url.replace(/^https?:\/\/(?:wa\.me\/|api\.whatsapp\.com\/send\?phone=)/, "");
+  }
+  if (platform === "email") {
+    return url.replace(/^mailto:/i, "");
+  }
+  if (platform === "telegram") {
+    return url.replace(/^https?:\/\/t\.me\//i, "").replace(/^@/, "");
   }
   return url;
 }


### PR DESCRIPTION
## Summary
- add Telegram username field and email address option when creating/editing links
- allow visiting email links in popup with copy support
- support Telegram and email formats in link utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ac93af6c48832ca13e43b48c6c13ea