### PR TITLE
fix: add default query function

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,5 @@
 // client/src/lib/queryClient.ts
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryFunctionContext } from "@tanstack/react-query";
 
 export async function apiRequest(method: string, url: string, data?: any) {
   const res = await fetch(url, {
@@ -21,9 +21,18 @@ export async function apiRequest(method: string, url: string, data?: any) {
   return JSON.parse(text);
 }
 
+// Default query function that uses the first element of the query key as the URL
+// and performs a GET request using the apiRequest helper above. This allows
+// components to specify only a `queryKey` when calling `useQuery`.
+async function defaultQueryFn({ queryKey }: QueryFunctionContext<[string, ...unknown[]]>) {
+  const [url] = queryKey;
+  return apiRequest("GET", url);
+}
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      queryFn: defaultQueryFn,
       refetchInterval: false,
       refetchOnWindowFocus: false,
       staleTime: Infinity,


### PR DESCRIPTION
## Summary
- add a default React Query `queryFn` to use the key as an API path

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TS error in dashboard.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68acc6fca3d8832ca2074eea6b8de62c