### PR TITLE
Fix support page back navigation

### DIFF
--- a/client/src/pages/support-page.tsx
+++ b/client/src/pages/support-page.tsx
@@ -298,7 +298,7 @@ export default function SupportPage() {
         <div className="container mx-auto px-4 py-12">
           <div className="relative">
             {/* Dynamic Back Button - Icon Only */}
-            <RouterLink href={user ? "/dashboard" : "/"} className="absolute left-0 top-0">
+            <RouterLink href="/" className="absolute left-0 top-0">
               <Button variant="ghost" size="sm" className="flex items-center hover:bg-background/50">
                 <ArrowLeft className="h-4 w-4" />
               </Button>


### PR DESCRIPTION
## Summary
- Ensure support page back arrow redirects to the root dashboard instead of a missing /dashboard route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68acd022d55c832cab56f36d23c49a5e