### PR TITLE
Sync Social Score Analysis with actual data

### DIFF
--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -154,18 +154,38 @@ const getTopLinks = (userLinksData: any[] | undefined) => {
     }));
 };
 
-const getSocialScoreData = () => ({
-  score: 78,
-  previousScore: 72,
-  change: 6,
-  scores: [
-    { category: "Profile Completeness", score: 85, avgScore: 65 },
-    { category: "Link Diversity", score: 70, avgScore: 60 },
-    { category: "Content Freshness", score: 65, avgScore: 50 },
-    { category: "Engagement Rate", score: 90, avgScore: 55 },
-    { category: "Feature Utilization", score: 80, avgScore: 40 },
-  ],
-});
+// Map API response to the shape expected by the Social Score card
+const getSocialScoreData = (socialScore: any) => {
+  if (!socialScore) {
+    return {
+      score: 0,
+      previousScore: 0,
+      change: 0,
+      scores: [] as {
+        category: string;
+        score: number;
+        avgScore: number;
+      }[],
+    };
+  }
+
+  const previousScore =
+    socialScore.historicalData?.[
+      socialScore.historicalData.length - 1
+    ]?.score || 0;
+
+  return {
+    score: socialScore.currentScore || 0,
+    previousScore,
+    change: (socialScore.currentScore || 0) - previousScore,
+    scores:
+      socialScore.compareData?.map((item: any) => ({
+        category: item.category,
+        score: item.userScore,
+        avgScore: item.avgScore,
+      })) || [],
+  };
+};
 
 // Stat Card Component
 interface StatCardProps {
@@ -334,7 +354,7 @@ export default function AnalyticsPage() {
   const historicalData = getHistoricalData();
   const platformData = getPlatformData(userLinks);
   const topLinks = getTopLinks(userLinks);
-  const socialScoreData = getSocialScoreData();
+  const socialScoreData = getSocialScoreData(socialScore);
 
   // Handle refresh
   const handleRefresh = async () => {


### PR DESCRIPTION
## Summary
- Map real `/api/social-score` data to the Social Score Analysis card
- Replace hardcoded sample data with live user stats

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: JSX and TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ad48a5f67c832c983f8095d5918c1b