### PR TITLE
fix: use string user IDs for referral links

### DIFF
--- a/client/src/pages/referral-links-fixed.tsx
+++ b/client/src/pages/referral-links-fixed.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -132,10 +132,25 @@ const ReferralLinks = () => {
   // States for dialogs
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
-  const [currentLink, setCurrentLink] = useState<ReferralLink | null>(null);
-  const [copiedId, setCopiedId] = useState<number | null>(null);
-  const [imageUploadType, setImageUploadType] = useState<'url' | 'file'>('url');
-  const [editImageUploadType, setEditImageUploadType] = useState<'url' | 'file'>('url');
+const [currentLink, setCurrentLink] = useState<ReferralLink | null>(null);
+const [copiedId, setCopiedId] = useState<number | null>(null);
+const [imageUploadType, setImageUploadType] = useState<'url' | 'file'>('url');
+const [editImageUploadType, setEditImageUploadType] = useState<'url' | 'file'>('url');
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const editFileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (imageUploadType === 'file') {
+      fileInputRef.current?.click();
+    }
+  }, [imageUploadType]);
+
+  useEffect(() => {
+    if (editImageUploadType === 'file') {
+      editFileInputRef.current?.click();
+    }
+  }, [editImageUploadType]);
 
   // Handle file upload for images
   const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>, formField: any) => {
@@ -190,9 +205,8 @@ const ReferralLinks = () => {
 
   // Create a new referral link
   const createLinkMutation = useMutation({
-    mutationFn: async (data: ReferralLinkFormValues) => {
-      const res = await apiRequest('POST', '/api/referral-links', data);
-      return await res.json();
+    mutationFn: async (data: Partial<ReferralLinkFormValues>) => {
+      return await apiRequest('POST', '/api/referral-links', data);
     },
     onSuccess: () => {
       toast({
@@ -215,8 +229,7 @@ const ReferralLinks = () => {
   // Update a referral link
   const updateLinkMutation = useMutation({
     mutationFn: async ({ id, data }: { id: number, data: Partial<ReferralLinkFormValues> }) => {
-      const res = await apiRequest('PATCH', `/api/referral-links/${id}`, data);
-      return await res.json();
+      return await apiRequest('PATCH', `/api/referral-links/${id}`, data);
     },
     onSuccess: () => {
       toast({
@@ -240,8 +253,7 @@ const ReferralLinks = () => {
   // Delete a referral link
   const deleteLinkMutation = useMutation({
     mutationFn: async (id: number) => {
-      const res = await apiRequest('DELETE', `/api/referral-links/${id}`);
-      return await res.json();
+      return await apiRequest('DELETE', `/api/referral-links/${id}`);
     },
     onSuccess: () => {
       toast({
@@ -262,8 +274,7 @@ const ReferralLinks = () => {
   // Update referral request status
   const updateRequestStatusMutation = useMutation({
     mutationFn: async ({ id, status }: { id: number, status: string }) => {
-      const res = await apiRequest('PATCH', `/api/referral-requests/${id}/status`, { status });
-      return await res.json();
+      return await apiRequest('PATCH', `/api/referral-requests/${id}/status`, { status });
     },
     onSuccess: () => {
       toast({
@@ -309,40 +320,69 @@ const ReferralLinks = () => {
   });
   
   // Handle form submission for creating a new referral link
+  const cleanPayload = (data: ReferralLinkFormValues) => {
+    const cleaned: any = { ...data };
+    Object.keys(cleaned).forEach((key) => {
+      if (cleaned[key as keyof ReferralLinkFormValues] === "") {
+        delete cleaned[key as keyof ReferralLinkFormValues];
+      }
+    });
+    return cleaned as Partial<ReferralLinkFormValues>;
+  };
+
   const onSubmit = (data: ReferralLinkFormValues) => {
-    createLinkMutation.mutate(data);
+    createLinkMutation.mutate(cleanPayload(data));
   };
   
   // Handle form submission for updating a referral link
   const onEditSubmit = (data: ReferralLinkFormValues) => {
     if (currentLink) {
-      updateLinkMutation.mutate({ id: currentLink.id, data });
+      updateLinkMutation.mutate({ id: currentLink.id, data: cleanPayload(data) });
     }
   };
   
   // Handle copy referral URL to clipboard
-  const handleCopyLink = (id: number) => {
+  const handleCopyLink = async (id: number) => {
     const baseUrl = window.location.origin;
     const referralUrl = `${baseUrl}/api/r/${id}`;
-    
-    navigator.clipboard.writeText(referralUrl)
-      .then(() => {
-        setCopiedId(id);
-        toast({
-          title: 'Copied!',
-          description: 'Referral link copied to clipboard',
-        });
-        
-        // Reset copied state after 2 seconds
-        setTimeout(() => setCopiedId(null), 2000);
-      })
-      .catch(err => {
-        toast({
-          title: 'Error',
-          description: 'Failed to copy link to clipboard',
-          variant: 'destructive',
-        });
+
+    try {
+      // Use modern clipboard API when available
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(referralUrl);
+      } else {
+        // Fallback for older browsers and non-secure contexts
+        const textarea = document.createElement('textarea');
+        textarea.value = referralUrl;
+        textarea.style.position = 'fixed';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+
+        const successful = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        if (!successful) {
+          throw new Error('Fallback copy command failed');
+        }
+      }
+
+      setCopiedId(id);
+      toast({
+        title: 'Copied!',
+        description: 'Referral link copied to clipboard',
       });
+
+      // Reset copied state after 2 seconds
+      setTimeout(() => setCopiedId(null), 2000);
+    } catch (err) {
+      console.error('Copy failed', err);
+      toast({
+        title: 'Error',
+        description: 'Failed to copy link to clipboard',
+        variant: 'destructive',
+      });
+    }
   };
   
   // Handle delete referral link
@@ -879,11 +919,12 @@ const ReferralLinks = () => {
                               accept="image/*"
                               onChange={(e) => handleImageUpload(e, field)}
                               className="cursor-pointer"
+                              ref={fileInputRef}
                             />
                             {field.value && field.value.startsWith('data:') && (
                               <div className="mt-2">
-                                <img 
-                                  src={field.value} 
+                                <img
+                                  src={field.value}
                                   alt="Preview" 
                                   className="h-16 w-16 object-cover rounded border"
                                 />
@@ -968,8 +1009,8 @@ const ReferralLinks = () => {
                 >
                   Cancel
                 </Button>
-                <Button type="submit">
-                  Create Link
+                <Button type="submit" disabled={createLinkMutation.isPending}>
+                  {createLinkMutation.isPending ? 'Creating...' : 'Create Link'}
                 </Button>
               </DialogFooter>
             </form>
@@ -1086,11 +1127,12 @@ const ReferralLinks = () => {
                               accept="image/*"
                               onChange={(e) => handleImageUpload(e, field)}
                               className="cursor-pointer"
+                              ref={editFileInputRef}
                             />
                             {field.value && field.value.startsWith('data:') && (
                               <div className="mt-2">
-                                <img 
-                                  src={field.value} 
+                                <img
+                                  src={field.value}
                                   alt="Preview" 
                                   className="h-16 w-16 object-cover rounded border"
                                 />
@@ -1175,8 +1217,8 @@ const ReferralLinks = () => {
                 >
                   Cancel
                 </Button>
-                <Button type="submit">
-                  Update Link
+                <Button type="submit" disabled={updateLinkMutation.isPending}>
+                  {updateLinkMutation.isPending ? 'Updating...' : 'Update Link'}
                 </Button>
               </DialogFooter>
             </form>

--- a/server/db-storage-enhanced.ts
+++ b/server/db-storage-enhanced.ts
@@ -1108,7 +1108,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   // Referral Links Feature
-  async getReferralLinks(userId: number): Promise<ReferralLink[]> {
+  async getReferralLinks(userId: string): Promise<ReferralLink[]> {
     return await db
       .select()
       .from(referralLinks)
@@ -1124,7 +1124,7 @@ export class EnhancedDatabaseStorage implements IStorage {
     return link;
   }
 
-  async createReferralLink(userId: number, link: InsertReferralLink): Promise<ReferralLink> {
+  async createReferralLink(userId: string, link: InsertReferralLink): Promise<ReferralLink> {
     const [newLink] = await db
       .insert(referralLinks)
       .values({

--- a/server/db-storage-new-features.ts
+++ b/server/db-storage-new-features.ts
@@ -83,7 +83,7 @@ export class EnhancedDatabaseStorage extends BaseStorage {
   // Referral Links Feature
 
   // Get all referral links for a user
-  async getReferralLinks(userId: number): Promise<ReferralLink[]> {
+  async getReferralLinks(userId: string): Promise<ReferralLink[]> {
     return await db
       .select()
       .from(referralLinks)
@@ -101,7 +101,7 @@ export class EnhancedDatabaseStorage extends BaseStorage {
   }
 
   // Create a new referral link
-  async createReferralLink(userId: number, link: InsertReferralLink): Promise<ReferralLink> {
+  async createReferralLink(userId: string, link: InsertReferralLink): Promise<ReferralLink> {
     const [newLink] = await db
       .insert(referralLinks)
       .values({

--- a/server/referral-routes.ts
+++ b/server/referral-routes.ts
@@ -15,12 +15,12 @@ function isAuthenticated(req: Request, res: Response, next: Function) {
 // Get all referral links for the authenticated user
 referralRouter.get("/referral-links", isAuthenticated, async (req: Request, res: Response) => {
   try {
-    const userId = req.user?.id;
+    const userId = req.user?.id as string | undefined;
     if (!userId) {
       return res.status(401).json({ message: 'User not authenticated' });
     }
 
-    const referralLinks = await storage.getReferralLinks(Number(userId));
+    const referralLinks = await storage.getReferralLinks(userId);
     res.json(referralLinks);
   } catch (error) {
     console.error('Error fetching referral links:', error);
@@ -31,7 +31,7 @@ referralRouter.get("/referral-links", isAuthenticated, async (req: Request, res:
 // Get a specific referral link
 referralRouter.get("/referral-links/:id", isAuthenticated, async (req: Request, res: Response) => {
   try {
-    const userId = req.user?.id;
+    const userId = req.user?.id as string | undefined;
     const { id } = req.params;
 
     if (!userId) {
@@ -44,7 +44,7 @@ referralRouter.get("/referral-links/:id", isAuthenticated, async (req: Request, 
       return res.status(404).json({ message: 'Referral link not found' });
     }
 
-    if (referralLink.userId !== Number(userId)) {
+    if (referralLink.userId !== userId) {
       return res.status(403).json({ message: 'Not authorized to access this referral link' });
     }
 
@@ -58,13 +58,13 @@ referralRouter.get("/referral-links/:id", isAuthenticated, async (req: Request, 
 // Create a new referral link
 referralRouter.post("/referral-links", isAuthenticated, async (req: Request, res: Response) => {
   try {
-    const userId = req.user?.id;
+    const userId = req.user?.id as string | undefined;
     if (!userId) {
       return res.status(401).json({ message: 'User not authenticated' });
     }
 
     const validatedData = insertReferralLinkSchema.parse(req.body);
-    const referralLink = await storage.createReferralLink(Number(userId), validatedData);
+    const referralLink = await storage.createReferralLink(userId, validatedData);
     
     res.status(201).json(referralLink);
   } catch (error) {
@@ -76,7 +76,7 @@ referralRouter.post("/referral-links", isAuthenticated, async (req: Request, res
 // Update a referral link
 referralRouter.patch("/referral-links/:id", isAuthenticated, async (req: Request, res: Response) => {
   try {
-    const userId = req.user?.id;
+    const userId = req.user?.id as string | undefined;
     const { id } = req.params;
 
     if (!userId) {
@@ -90,7 +90,7 @@ referralRouter.patch("/referral-links/:id", isAuthenticated, async (req: Request
       return res.status(404).json({ message: 'Referral link not found' });
     }
 
-    if (existingLink.userId !== Number(userId)) {
+    if (existingLink.userId !== userId) {
       return res.status(403).json({ message: 'Not authorized to update this referral link' });
     }
 
@@ -105,7 +105,7 @@ referralRouter.patch("/referral-links/:id", isAuthenticated, async (req: Request
 // Delete a referral link
 referralRouter.delete("/referral-links/:id", isAuthenticated, async (req: Request, res: Response) => {
   try {
-    const userId = req.user?.id;
+    const userId = req.user?.id as string | undefined;
     const { id } = req.params;
 
     if (!userId) {
@@ -119,7 +119,7 @@ referralRouter.delete("/referral-links/:id", isAuthenticated, async (req: Reques
       return res.status(404).json({ message: 'Referral link not found' });
     }
 
-    if (existingLink.userId !== Number(userId)) {
+    if (existingLink.userId !== userId) {
       return res.status(403).json({ message: 'Not authorized to delete this referral link' });
     }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -111,9 +111,9 @@ export interface IStorage {
   discoverUsers(userId: number, filters: any): Promise<User[]>;
   
   // Referral Links Feature
-  getReferralLinks(userId: number): Promise<ReferralLink[]>;
+  getReferralLinks(userId: string): Promise<ReferralLink[]>;
   getReferralLinkById(id: number): Promise<ReferralLink | undefined>;
-  createReferralLink(userId: number, link: InsertReferralLink): Promise<ReferralLink>;
+  createReferralLink(userId: string, link: InsertReferralLink): Promise<ReferralLink>;
   updateReferralLink(id: number, updates: Partial<InsertReferralLink>): Promise<ReferralLink | undefined>;
   deleteReferralLink(id: number): Promise<boolean>;
   incrementReferralLinkClicks(id: number): Promise<ReferralLink | undefined>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -420,6 +420,11 @@ export const insertReferralLinkSchema = createInsertSchema(referralLinks).pick({
   linkType: true,
   referenceUserId: true,
   referenceCompany: true,
+}).partial({
+  description: true,
+  image: true,
+  referenceUserId: true,
+  referenceCompany: true,
 });
 
 // Link schemas


### PR DESCRIPTION
## Summary
- provide clipboard fallback so referral link copy works across browsers
- automatically trigger file chooser when switching to Upload for referral link image
- strip empty optional fields before saving to avoid 400 errors
- fix referral link mutations by using apiRequest return values and add pending button states
- allow optional referral link fields in server schema to prevent creation errors
- treat user IDs as strings in referral link routes and storage to prevent 400 errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ad71734c9c832c9dea0b0ebe538316