### PR TITLE
fix: improve referral link clipboard copy

### DIFF
--- a/client/src/pages/referral-links-fixed.tsx
+++ b/client/src/pages/referral-links-fixed.tsx
@@ -377,13 +377,10 @@ const [links, setLinks] = useState<ReferralLink[]>([]);
   };
 
   // Handle copy referral URL to clipboard
-  const handleCopyLink = async (id: number) => {
-    const baseUrl = window.location.origin;
-    const referralUrl = `${baseUrl}/api/r/${id}`;
-
+  const handleCopyLink = async (link: ReferralLink) => {
     try {
-      await copyTextToClipboard(referralUrl);
-      setCopiedId(id);
+      await copyTextToClipboard(link.url);
+      setCopiedId(link.id);
       toast({
         title: 'Copied!',
         description: 'Referral link copied to clipboard',
@@ -1320,7 +1317,7 @@ const ReferralLinkCard = ({
   isCopied
 }: {
   link: ReferralLink;
-  onCopy: (id: number) => void;
+  onCopy: (link: ReferralLink) => void;
   onEdit: () => void;
   onDelete: () => void;
   onPin: () => void;
@@ -1442,7 +1439,7 @@ const ReferralLinkCard = ({
                 Move Down
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link.id); }}>
+              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link); }}>
                 {isCopied ? (
                   <>
                     <Check className="h-4 w-4 mr-2" />
@@ -1495,7 +1492,7 @@ const ReferralLinkCard = ({
               size="sm"
               onClick={(e) => {
                 e.stopPropagation();
-                onCopy(link.id);
+                onCopy(link);
               }}
               className="h-6 w-6 p-0"
             >

--- a/client/src/pages/referral-links-fixed.tsx
+++ b/client/src/pages/referral-links-fixed.tsx
@@ -38,8 +38,8 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
   Link, Users, UserPlus, ExternalLink, Copy, Check, Trash2,
-  Edit, Heart, Award, Gift, User, Briefcase, BarChart3, Plus,
-  Upload, Image as ImageIcon, Pin, ArrowUp, ArrowDown
+  Edit, Award, Gift, Briefcase, BarChart3, Plus,
+  Upload, Pin, ArrowUp, ArrowDown
 } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -88,43 +88,6 @@ const referralLinkSchema = z.object({
 
 type ReferralLinkFormValues = z.infer<typeof referralLinkSchema>;
 
-// Sample data for demo
-const sampleLinks: ReferralLink[] = [
-  {
-    id: 1,
-    userId: 1,
-    title: 'My Designer Friend',
-    url: 'https://example.com/designer',
-    description: 'Check out my friend\'s amazing design portfolio',
-    linkType: 'friend',
-    clicks: 24,
-    createdAt: '2024-05-01T10:30:00Z'
-  },
-  {
-    id: 2,
-    userId: 1,
-    title: 'Acme Design Tools',
-    url: 'https://acmedesign.com',
-    description: 'The best design tools I use every day',
-    linkType: 'sponsor',
-    referenceCompany: 'Acme Design',
-    image: 'https://placehold.co/50x50',
-    clicks: 47,
-    createdAt: '2024-05-05T14:22:00Z'
-  },
-  {
-    id: 3,
-    userId: 1,
-    title: 'Premium Hosting Service',
-    url: 'https://hostingservice.com/ref123',
-    description: 'Get 20% off your first month of hosting with my code',
-    linkType: 'affiliate',
-    referenceCompany: 'Premium Hosting',
-    clicks: 12,
-    createdAt: '2024-05-10T09:15:00Z'
-  }
-];
-
 const ReferralLinks = () => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -133,11 +96,11 @@ const ReferralLinks = () => {
   // States for dialogs
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
-const [currentLink, setCurrentLink] = useState<ReferralLink | null>(null);
-const [copiedId, setCopiedId] = useState<number | null>(null);
-const [imageUploadType, setImageUploadType] = useState<'url' | 'file'>('url');
-const [editImageUploadType, setEditImageUploadType] = useState<'url' | 'file'>('url');
-const [links, setLinks] = useState<ReferralLink[]>([]);
+  const [currentLink, setCurrentLink] = useState<ReferralLink | null>(null);
+  const [copiedId, setCopiedId] = useState<number | null>(null);
+  const [imageUploadType, setImageUploadType] = useState<'url' | 'file'>('url');
+  const [editImageUploadType, setEditImageUploadType] = useState<'url' | 'file'>('url');
+  const [links, setLinks] = useState<ReferralLink[]>([]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const editFileInputRef = useRef<HTMLInputElement>(null);

--- a/client/src/pages/referral-links-fixed.tsx
+++ b/client/src/pages/referral-links-fixed.tsx
@@ -351,34 +351,39 @@ const [links, setLinks] = useState<ReferralLink[]>([]);
   
   // Copy to clipboard with graceful fallback for older browsers or insecure contexts
   const copyTextToClipboard = async (text: string) => {
-    if (navigator.clipboard && window.isSecureContext) {
-      await navigator.clipboard.writeText(text);
-      return;
-    }
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+      throw new Error('Clipboard API not available');
+    } catch {
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      textArea.setAttribute('readonly', '');
+      textArea.style.position = 'fixed';
+      textArea.style.left = '-9999px';
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
 
-    const textArea = document.createElement('textarea');
-    textArea.value = text;
-    textArea.setAttribute('readonly', '');
-    textArea.style.position = 'absolute';
-    textArea.style.left = '-9999px';
-    textArea.style.top = (document.body.scrollTop || 0) + 'px';
-    document.body.appendChild(textArea);
-    textArea.select();
-    textArea.setSelectionRange(0, textArea.value.length);
+      const successful = document.execCommand('copy');
+      document.body.removeChild(textArea);
 
-    const successful = document.execCommand('copy');
-    document.body.removeChild(textArea);
-
-    if (!successful) {
-      throw new Error('Copy command was unsuccessful');
+      if (!successful) {
+        throw new Error('Copy command was unsuccessful');
+      }
     }
   };
 
   // Handle copy referral URL to clipboard
-  const handleCopyLink = async (link: ReferralLink) => {
+  const handleCopyLink = async (id: number) => {
+    const baseUrl = window.location.origin;
+    const referralUrl = `${baseUrl}/api/r/${id}`;
+
     try {
-      await copyTextToClipboard(link.url);
-      setCopiedId(link.id);
+      await copyTextToClipboard(referralUrl);
+      setCopiedId(id);
       toast({
         title: 'Copied!',
         description: 'Referral link copied to clipboard',
@@ -1315,7 +1320,7 @@ const ReferralLinkCard = ({
   isCopied
 }: {
   link: ReferralLink;
-  onCopy: (link: ReferralLink) => void;
+  onCopy: (id: number) => void;
   onEdit: () => void;
   onDelete: () => void;
   onPin: () => void;
@@ -1437,7 +1442,7 @@ const ReferralLinkCard = ({
                 Move Down
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link); }}>
+              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link.id); }}>
                 {isCopied ? (
                   <>
                     <Check className="h-4 w-4 mr-2" />
@@ -1490,7 +1495,7 @@ const ReferralLinkCard = ({
               size="sm"
               onClick={(e) => {
                 e.stopPropagation();
-                onCopy(link);
+                onCopy(link.id);
               }}
               className="h-6 w-6 p-0"
             >

--- a/client/src/pages/referral-links-fixed.tsx
+++ b/client/src/pages/referral-links-fixed.tsx
@@ -416,18 +416,27 @@ const [links, setLinks] = useState<ReferralLink[]>([]);
 
   const handlePinLink = (id: number) => {
     setLinks(prev => {
-      const updated = prev.map(l =>
-        l.id === id ? { ...l, pinned: !l.pinned } : l
-      );
-      const sorted = [...updated].sort(
-        (a, b) => Number(b.pinned) - Number(a.pinned)
-      );
-      const isPinned = sorted.find(l => l.id === id)?.pinned;
+      const index = prev.findIndex(l => l.id === id);
+      if (index === -1) return prev;
+
+      const link = { ...prev[index], pinned: !prev[index].pinned };
+      const newLinks = [...prev];
+      newLinks.splice(index, 1);
+
+      if (link.pinned) {
+        newLinks.unshift(link);
+      } else {
+        const firstUnpinned = newLinks.findIndex(l => !l.pinned);
+        if (firstUnpinned === -1) newLinks.push(link);
+        else newLinks.splice(firstUnpinned, 0, link);
+      }
+
       toast({
         title: 'Success',
-        description: isPinned ? 'Link pinned' : 'Link unpinned',
+        description: link.pinned ? 'Link pinned' : 'Link unpinned',
       });
-      return sorted;
+
+      return newLinks;
     });
   };
 

--- a/client/src/pages/referral-links-fixed.tsx
+++ b/client/src/pages/referral-links-fixed.tsx
@@ -351,28 +351,26 @@ const [links, setLinks] = useState<ReferralLink[]>([]);
   
   // Copy to clipboard with graceful fallback for older browsers or insecure contexts
   const copyTextToClipboard = async (text: string) => {
-    try {
-      if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(text);
-        return;
-      }
-      throw new Error('Clipboard API not available');
-    } catch {
-      const textArea = document.createElement('textarea');
-      textArea.value = text;
-      textArea.setAttribute('readonly', '');
-      textArea.style.position = 'fixed';
-      textArea.style.left = '-9999px';
-      document.body.appendChild(textArea);
-      textArea.focus();
-      textArea.select();
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
 
-      const successful = document.execCommand('copy');
-      document.body.removeChild(textArea);
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.setAttribute('readonly', '');
+    textArea.style.position = 'absolute';
+    textArea.style.left = '-9999px';
+    textArea.style.top = '0';
+    document.body.appendChild(textArea);
+    textArea.select();
+    textArea.setSelectionRange(0, textArea.value.length);
 
-      if (!successful) {
-        throw new Error('Copy command was unsuccessful');
-      }
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textArea);
+
+    if (!successful) {
+      throw new Error('Copy command was unsuccessful');
     }
   };
 
@@ -1439,7 +1437,7 @@ const ReferralLinkCard = ({
                 Move Down
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link); }}>
+              <DropdownMenuItem onClick={() => onCopy(link)}>
                 {isCopied ? (
                   <>
                     <Check className="h-4 w-4 mr-2" />

--- a/client/src/pages/referral-links-fixed.tsx
+++ b/client/src/pages/referral-links-fixed.tsx
@@ -359,10 +359,11 @@ const [links, setLinks] = useState<ReferralLink[]>([]);
     const textArea = document.createElement('textarea');
     textArea.value = text;
     textArea.setAttribute('readonly', '');
-    textArea.style.position = 'absolute';
+    textArea.style.position = 'fixed';
     textArea.style.left = '-9999px';
     textArea.style.top = '0';
     document.body.appendChild(textArea);
+    textArea.focus();
     textArea.select();
     textArea.setSelectionRange(0, textArea.value.length);
 

--- a/client/src/pages/referral-links-fixed.tsx
+++ b/client/src/pages/referral-links-fixed.tsx
@@ -351,27 +351,30 @@ const [links, setLinks] = useState<ReferralLink[]>([]);
   
   // Copy to clipboard with graceful fallback for older browsers or insecure contexts
   const copyTextToClipboard = async (text: string) => {
-    if (navigator.clipboard && window.isSecureContext) {
-      await navigator.clipboard.writeText(text);
-      return;
-    }
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+      throw new Error('Clipboard API not available');
+    } catch {
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      textArea.setAttribute('readonly', '');
+      textArea.style.position = 'fixed';
+      textArea.style.left = '-9999px';
+      textArea.style.top = '0';
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      textArea.setSelectionRange(0, textArea.value.length);
 
-    const textArea = document.createElement('textarea');
-    textArea.value = text;
-    textArea.setAttribute('readonly', '');
-    textArea.style.position = 'fixed';
-    textArea.style.left = '-9999px';
-    textArea.style.top = '0';
-    document.body.appendChild(textArea);
-    textArea.focus();
-    textArea.select();
-    textArea.setSelectionRange(0, textArea.value.length);
+      const successful = document.execCommand('copy');
+      document.body.removeChild(textArea);
 
-    const successful = document.execCommand('copy');
-    document.body.removeChild(textArea);
-
-    if (!successful) {
-      throw new Error('Copy command was unsuccessful');
+      if (!successful) {
+        throw new Error('Copy command was unsuccessful');
+      }
     }
   };
 

--- a/client/src/pages/referral-links.tsx
+++ b/client/src/pages/referral-links.tsx
@@ -253,30 +253,51 @@ const ReferralLinks = () => {
       updateLinkMutation.mutate({ id: currentLink.id, data });
     }
   };
-  
+
+  // Copy text to clipboard with fallback for unsupported browsers
+  const copyTextToClipboard = async (text: string) => {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.setAttribute('readonly', '');
+    textArea.style.position = 'absolute';
+    textArea.style.left = '-9999px';
+    textArea.style.top = (document.body.scrollTop || 0) + 'px';
+    document.body.appendChild(textArea);
+    textArea.select();
+    textArea.setSelectionRange(0, textArea.value.length);
+
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textArea);
+
+    if (!successful) {
+      throw new Error('Copy command was unsuccessful');
+    }
+  };
+
   // Handle copy referral URL to clipboard
-  const handleCopyLink = (id: number) => {
-    const baseUrl = window.location.origin;
-    const referralUrl = `${baseUrl}/api/r/${id}`;
-    
-    navigator.clipboard.writeText(referralUrl)
-      .then(() => {
-        setCopiedId(id);
-        toast({
-          title: 'Copied!',
-          description: 'Referral link copied to clipboard',
-        });
-        
-        // Reset copied state after 2 seconds
-        setTimeout(() => setCopiedId(null), 2000);
-      })
-      .catch(err => {
-        toast({
-          title: 'Error',
-          description: 'Failed to copy link to clipboard',
-          variant: 'destructive',
-        });
+  const handleCopyLink = async (link: ReferralLink) => {
+    try {
+      await copyTextToClipboard(link.url);
+      setCopiedId(link.id);
+      toast({
+        title: 'Copied!',
+        description: 'Referral link copied to clipboard',
       });
+
+      // Reset copied state after 2 seconds
+      setTimeout(() => setCopiedId(null), 2000);
+    } catch (err) {
+      toast({
+        title: 'Error',
+        description: 'Failed to copy link to clipboard',
+        variant: 'destructive',
+      });
+    }
   };
   
   // Handle delete referral link
@@ -422,10 +443,10 @@ const ReferralLinks = () => {
                   ) : referralLinks && referralLinks.length > 0 ? (
                     <div className="space-y-4">
                       {referralLinks.map((link) => (
-                        <ReferralLinkCard 
+                        <ReferralLinkCard
                           key={link.id}
                           link={link}
-                          onCopy={() => handleCopyLink(link.id)}
+                          onCopy={handleCopyLink}
                           onEdit={() => handleEditLink(link)}
                           onDelete={() => handleDeleteLink(link.id)}
                           isCopied={copiedId === link.id}
@@ -470,10 +491,10 @@ const ReferralLinks = () => {
                   ) : getFriendLinks().length > 0 ? (
                     <div className="space-y-4">
                       {getFriendLinks().map((link) => (
-                        <ReferralLinkCard 
+                        <ReferralLinkCard
                           key={link.id}
                           link={link}
-                          onCopy={() => handleCopyLink(link.id)}
+                          onCopy={handleCopyLink}
                           onEdit={() => handleEditLink(link)}
                           onDelete={() => handleDeleteLink(link.id)}
                           isCopied={copiedId === link.id}
@@ -521,10 +542,10 @@ const ReferralLinks = () => {
                   ) : getSponsorLinks().length > 0 ? (
                     <div className="space-y-4">
                       {getSponsorLinks().map((link) => (
-                        <ReferralLinkCard 
+                        <ReferralLinkCard
                           key={link.id}
                           link={link}
-                          onCopy={() => handleCopyLink(link.id)}
+                          onCopy={handleCopyLink}
                           onEdit={() => handleEditLink(link)}
                           onDelete={() => handleDeleteLink(link.id)}
                           isCopied={copiedId === link.id}
@@ -572,10 +593,10 @@ const ReferralLinks = () => {
                   ) : getAffiliateLinks().length > 0 ? (
                     <div className="space-y-4">
                       {getAffiliateLinks().map((link) => (
-                        <ReferralLinkCard 
+                        <ReferralLinkCard
                           key={link.id}
                           link={link}
-                          onCopy={() => handleCopyLink(link.id)}
+                          onCopy={handleCopyLink}
                           onEdit={() => handleEditLink(link)}
                           onDelete={() => handleDeleteLink(link.id)}
                           isCopied={copiedId === link.id}
@@ -1127,16 +1148,16 @@ const ReferralLinks = () => {
 };
 
 // Referral Link Card Component
-const ReferralLinkCard = ({ 
-  link, 
-  onCopy, 
-  onEdit, 
+const ReferralLinkCard = ({
+  link,
+  onCopy,
+  onEdit,
   onDelete,
   isCopied
-}: { 
-  link: ReferralLink; 
-  onCopy: () => void; 
-  onEdit: () => void; 
+}: {
+  link: ReferralLink;
+  onCopy: (link: ReferralLink) => void;
+  onEdit: () => void;
   onDelete: () => void;
   isCopied: boolean;
 }) => {
@@ -1237,7 +1258,7 @@ const ReferralLinkCard = ({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
-              <DropdownMenuItem onClick={onCopy}>
+              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link); }}>
                 {isCopied ? (
                   <>
                     <Check className="h-4 w-4 mr-2" />
@@ -1277,10 +1298,10 @@ const ReferralLinkCard = ({
           <p className="text-sm font-mono truncate flex-1">
             {link.url}
           </p>
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             size="sm"
-            onClick={onCopy}
+            onClick={(e) => { e.stopPropagation(); onCopy(link); }}
             className="h-7 px-2"
           >
             {isCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}

--- a/client/src/pages/referral-links.tsx
+++ b/client/src/pages/referral-links.tsx
@@ -262,30 +262,28 @@ const ReferralLinks = () => {
     }
   };
 
-  // Copy text to clipboard with fallback for unsupported browsers
+  // Copy text to clipboard with graceful fallback
   const copyTextToClipboard = async (text: string) => {
-    try {
-      if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(text);
-        return;
-      }
-      throw new Error('Clipboard API not available');
-    } catch {
-      const textArea = document.createElement('textarea');
-      textArea.value = text;
-      textArea.setAttribute('readonly', '');
-      textArea.style.position = 'fixed';
-      textArea.style.left = '-9999px';
-      document.body.appendChild(textArea);
-      textArea.focus();
-      textArea.select();
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
 
-      const successful = document.execCommand('copy');
-      document.body.removeChild(textArea);
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.setAttribute('readonly', '');
+    textArea.style.position = 'absolute';
+    textArea.style.left = '-9999px';
+    textArea.style.top = '0';
+    document.body.appendChild(textArea);
+    textArea.select();
+    textArea.setSelectionRange(0, textArea.value.length);
 
-      if (!successful) {
-        throw new Error('Copy command was unsuccessful');
-      }
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textArea);
+
+    if (!successful) {
+      throw new Error('Copy command was unsuccessful');
     }
   };
 
@@ -1351,7 +1349,7 @@ const ReferralLinkCard = ({
                 Move Down
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link); }}>
+              <DropdownMenuItem onClick={() => onCopy(link)}>
                 {isCopied ? (
                   <>
                     <Check className="h-4 w-4 mr-2" />

--- a/client/src/pages/referral-links.tsx
+++ b/client/src/pages/referral-links.tsx
@@ -332,18 +332,27 @@ const ReferralLinks = () => {
 
   const handlePinLink = (id: number) => {
     setLinks(prev => {
-      const updated = prev.map(l =>
-        l.id === id ? { ...l, pinned: !l.pinned } : l
-      );
-      const sorted = [...updated].sort(
-        (a, b) => Number(b.pinned) - Number(a.pinned)
-      );
-      const isPinned = sorted.find(l => l.id === id)?.pinned;
+      const index = prev.findIndex(l => l.id === id);
+      if (index === -1) return prev;
+
+      const link = { ...prev[index], pinned: !prev[index].pinned };
+      const newLinks = [...prev];
+      newLinks.splice(index, 1);
+
+      if (link.pinned) {
+        newLinks.unshift(link);
+      } else {
+        const firstUnpinned = newLinks.findIndex(l => !l.pinned);
+        if (firstUnpinned === -1) newLinks.push(link);
+        else newLinks.splice(firstUnpinned, 0, link);
+      }
+
       toast({
         title: 'Success',
-        description: isPinned ? 'Link pinned' : 'Link unpinned',
+        description: link.pinned ? 'Link pinned' : 'Link unpinned',
       });
-      return sorted;
+
+      return newLinks;
     });
   };
 

--- a/client/src/pages/referral-links.tsx
+++ b/client/src/pages/referral-links.tsx
@@ -290,13 +290,10 @@ const ReferralLinks = () => {
   };
 
   // Handle copy referral URL to clipboard
-  const handleCopyLink = async (id: number) => {
-    const baseUrl = window.location.origin;
-    const referralUrl = `${baseUrl}/api/r/${id}`;
-
+  const handleCopyLink = async (link: ReferralLink) => {
     try {
-      await copyTextToClipboard(referralUrl);
-      setCopiedId(id);
+      await copyTextToClipboard(link.url);
+      setCopiedId(link.id);
       toast({
         title: 'Copied!',
         description: 'Referral link copied to clipboard',
@@ -1236,7 +1233,7 @@ const ReferralLinkCard = ({
   isCopied
 }: {
   link: ReferralLink;
-  onCopy: (id: number) => void;
+  onCopy: (link: ReferralLink) => void;
   onEdit: () => void;
   onDelete: () => void;
   onPin: () => void;
@@ -1354,7 +1351,7 @@ const ReferralLinkCard = ({
                 Move Down
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link.id); }}>
+              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); onCopy(link); }}>
                 {isCopied ? (
                   <>
                     <Check className="h-4 w-4 mr-2" />
@@ -1397,7 +1394,7 @@ const ReferralLinkCard = ({
           <Button
             variant="outline"
             size="sm"
-            onClick={(e) => { e.stopPropagation(); onCopy(link.id); }}
+            onClick={(e) => { e.stopPropagation(); onCopy(link); }}
             className="h-7 px-2"
           >
             {isCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}

--- a/client/src/pages/referral-links.tsx
+++ b/client/src/pages/referral-links.tsx
@@ -264,26 +264,30 @@ const ReferralLinks = () => {
 
   // Copy text to clipboard with graceful fallback
   const copyTextToClipboard = async (text: string) => {
-    if (navigator.clipboard && window.isSecureContext) {
-      await navigator.clipboard.writeText(text);
-      return;
-    }
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+      throw new Error('Clipboard API not available');
+    } catch {
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      textArea.setAttribute('readonly', '');
+      textArea.style.position = 'fixed';
+      textArea.style.left = '-9999px';
+      textArea.style.top = '0';
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      textArea.setSelectionRange(0, textArea.value.length);
 
-    const textArea = document.createElement('textarea');
-    textArea.value = text;
-    textArea.setAttribute('readonly', '');
-    textArea.style.position = 'absolute';
-    textArea.style.left = '-9999px';
-    textArea.style.top = '0';
-    document.body.appendChild(textArea);
-    textArea.select();
-    textArea.setSelectionRange(0, textArea.value.length);
+      const successful = document.execCommand('copy');
+      document.body.removeChild(textArea);
 
-    const successful = document.execCommand('copy');
-    document.body.removeChild(textArea);
-
-    if (!successful) {
-      throw new Error('Copy command was unsuccessful');
+      if (!successful) {
+        throw new Error('Copy command was unsuccessful');
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- use a more robust clipboard fallback to ensure copying works when `navigator.clipboard` isn't available
- trigger copying from dropdown and inline button using `onSelect`/`stopPropagation` so the browser sees a direct user gesture
- copy the user-provided URL instead of an internal API path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: error TS1005: ';' expected, etc. in dashboard and other pages)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8b5f1478832c9e03c5543046d42c