### PR TITLE
Fix branding suggestion generation

### DIFF
--- a/client/src/components/branding-suggester.tsx
+++ b/client/src/components/branding-suggester.tsx
@@ -42,12 +42,11 @@ export function BrandingSuggester({ className = '', userId, username }: Branding
   // Handle generating branding suggestions
   const brandingMutation = useMutation({
     mutationFn: async () => {
-      const response = await apiRequest('POST', '/api/branding/suggest', {
+      return await apiRequest('POST', '/api/branding/suggest', {
         profession,
         interests,
         socialAccounts,
       });
-      return await response.json();
     },
     onSuccess: () => {
       toast({

--- a/client/src/pages/branding.tsx
+++ b/client/src/pages/branding.tsx
@@ -66,8 +66,7 @@ export default function BrandingPage() {
   // Branding generation mutation
   const generateBrandingMutation = useMutation({
     mutationFn: async (data: any) => {
-      const response = await apiRequest("POST", "/api/branding/suggest", data);
-      return await response.json();
+      return await apiRequest("POST", "/api/branding/suggest", data);
     },
     onSuccess: (data) => {
       setBrandingData(data.suggestions);


### PR DESCRIPTION
## Summary
- stop double JSON parsing in branding suggestion mutations
- handle API response directly when generating suggestions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0c026348832ca3a35da187efab43