### PR TITLE
feat: show skills on profile

### DIFF
--- a/client/src/pages/collaboration-page.tsx
+++ b/client/src/pages/collaboration-page.tsx
@@ -249,24 +249,30 @@ export default function CollaborationPage() {
       const res = await fetch('/api/add-skill', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ skill: trimmed, level: levelMap[newSkillLevel] || 2 })
       });
-      if (res.ok) {
-        const saved = await res.json();
-        const reverseLevel: Record<number, string> = {1:'beginner',2:'intermediate',3:'advanced',4:'expert'};
-        setUserSkills([...userSkills, {
-          id: saved.id,
-          name: saved.skill || saved.name,
-          level: reverseLevel[saved.level] || 'intermediate'
-        }]);
-        setNewSkill('');
-        setNewSkillLevel('intermediate');
-        setIsAddSkillOpen(false);
-        toast({
-          title: 'Skill Added',
-          description: `"${trimmed}" (${skillLevels.find(l => l.id === newSkillLevel)?.name}) has been added to your skills.`,
-        });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        toast({ title: 'Error', description: error.message || 'Failed to add skill', variant: 'destructive' });
+        return;
       }
+
+      const saved = await res.json();
+      const reverseLevel: Record<number, string> = {1:'beginner',2:'intermediate',3:'advanced',4:'expert'};
+      setUserSkills([...userSkills, {
+        id: saved.id,
+        name: saved.skill || saved.name,
+        level: reverseLevel[saved.level] || 'intermediate'
+      }]);
+      setNewSkill('');
+      setNewSkillLevel('intermediate');
+      setIsAddSkillOpen(false);
+      toast({
+        title: 'Skill Added',
+        description: `"${trimmed}" (${skillLevels.find(l => l.id === newSkillLevel)?.name}) has been added to your skills.`,
+      });
     } catch (err) {
       console.error('Failed to add skill', err);
       toast({ title: 'Error', description: 'Failed to add skill', variant: 'destructive' });
@@ -278,15 +284,21 @@ export default function CollaborationPage() {
       const res = await fetch('/api/add-skill', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ id: skillId })
       });
-      if (res.ok) {
-        setUserSkills(userSkills.filter(skill => skill.id !== skillId));
-        toast({
-          title: 'Skill Removed',
-          description: `"${skillName}" has been removed from your skills.`,
-        });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        toast({ title: 'Error', description: error.message || 'Failed to remove skill', variant: 'destructive' });
+        return;
       }
+
+      setUserSkills(userSkills.filter(skill => skill.id !== skillId));
+      toast({
+        title: 'Skill Removed',
+        description: `"${skillName}" has been removed from your skills.`,
+      });
     } catch (err) {
       console.error('Failed to remove skill', err);
       toast({ title: 'Error', description: 'Failed to remove skill', variant: 'destructive' });

--- a/client/src/pages/collaboration-page.tsx
+++ b/client/src/pages/collaboration-page.tsx
@@ -168,8 +168,9 @@ const skillLevels = [
 ];
 
 interface UserSkill {
+  id: string;
   name: string;
-  level: string;
+  level: string; // stored as "beginner" | "intermediate" | "advanced" | "expert"
 }
 
 export default function CollaborationPage() {
@@ -219,25 +220,77 @@ export default function CollaborationPage() {
     navigate(`/profile/${username}`);
   };
 
-  const handleAddSkill = () => {
-    if (newSkill.trim() && !userSkills.some(skill => skill.name === newSkill.trim())) {
-      setUserSkills([...userSkills, { name: newSkill.trim(), level: newSkillLevel }]);
-      setNewSkill("");
-      setNewSkillLevel("intermediate");
-      setIsAddSkillOpen(false);
-      toast({
-        title: "Skill Added",
-        description: `"${newSkill.trim()}" (${skillLevels.find(l => l.id === newSkillLevel)?.name}) has been added to your skills.`,
+  useEffect(() => {
+    const fetchSkills = async () => {
+      try {
+        const res = await fetch('/api/profile');
+        if (res.ok) {
+          const data = await res.json();
+          const levelMap: Record<number, string> = {1:'beginner',2:'intermediate',3:'advanced',4:'expert'};
+          const fetched = (data.skills || []).map((s: any) => ({
+            id: s.id,
+            name: s.skill || s.name,
+            level: levelMap[s.level] || 'intermediate'
+          }));
+          setUserSkills(fetched);
+        }
+      } catch (err) {
+        console.error('Failed to load skills', err);
+      }
+    };
+    fetchSkills();
+  }, []);
+
+  const handleAddSkill = async () => {
+    const trimmed = newSkill.trim();
+    if (!trimmed || userSkills.some(skill => skill.name === trimmed)) return;
+    const levelMap: Record<string, number> = { beginner:1, intermediate:2, advanced:3, expert:4 };
+    try {
+      const res = await fetch('/api/add-skill', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ skill: trimmed, level: levelMap[newSkillLevel] || 2 })
       });
+      if (res.ok) {
+        const saved = await res.json();
+        const reverseLevel: Record<number, string> = {1:'beginner',2:'intermediate',3:'advanced',4:'expert'};
+        setUserSkills([...userSkills, {
+          id: saved.id,
+          name: saved.skill || saved.name,
+          level: reverseLevel[saved.level] || 'intermediate'
+        }]);
+        setNewSkill('');
+        setNewSkillLevel('intermediate');
+        setIsAddSkillOpen(false);
+        toast({
+          title: 'Skill Added',
+          description: `"${trimmed}" (${skillLevels.find(l => l.id === newSkillLevel)?.name}) has been added to your skills.`,
+        });
+      }
+    } catch (err) {
+      console.error('Failed to add skill', err);
+      toast({ title: 'Error', description: 'Failed to add skill', variant: 'destructive' });
     }
   };
 
-  const handleRemoveSkill = (skillToRemove: string) => {
-    setUserSkills(userSkills.filter(skill => skill.name !== skillToRemove));
-    toast({
-      title: "Skill Removed",
-      description: `"${skillToRemove}" has been removed from your skills.`,
-    });
+  const handleRemoveSkill = async (skillId: string, skillName: string) => {
+    try {
+      const res = await fetch('/api/add-skill', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: skillId })
+      });
+      if (res.ok) {
+        setUserSkills(userSkills.filter(skill => skill.id !== skillId));
+        toast({
+          title: 'Skill Removed',
+          description: `"${skillName}" has been removed from your skills.`,
+        });
+      }
+    } catch (err) {
+      console.error('Failed to remove skill', err);
+      toast({ title: 'Error', description: 'Failed to remove skill', variant: 'destructive' });
+    }
   };
 
   if (!user) {
@@ -428,7 +481,7 @@ export default function CollaborationPage() {
                   ) : (
                     <div className="space-y-2">
                       {userSkills.map((skill) => (
-                        <div key={skill.name} className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded-md px-3 py-2">
+                        <div key={skill.id} className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded-md px-3 py-2">
                           <div className="flex-1">
                             <div className="text-sm font-medium">{skill.name}</div>
                             <div className="text-xs text-gray-500">{skillLevels.find(l => l.id === skill.level)?.name}</div>
@@ -436,7 +489,7 @@ export default function CollaborationPage() {
                           <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => handleRemoveSkill(skill.name)}
+                            onClick={() => handleRemoveSkill(skill.id, skill.name)}
                             className="h-6 w-6 p-0 hover:bg-red-100 hover:text-red-600"
                           >
                             <X className="h-3 w-3" />

--- a/client/src/pages/visitor-profile-new.tsx
+++ b/client/src/pages/visitor-profile-new.tsx
@@ -1151,72 +1151,70 @@ export default function VisitorProfileNew() {
                 </div>
 
                 {/* Skills Button */}
-                {skills.length > 0 && (
-                  <div className="mb-4">
-                    <Dialog>
-                      <DialogTrigger asChild>
-                        <Button
-                          variant="outline"
-                          className="w-full hover:bg-blue-50 border-blue-200"
-                        >
-                          <Briefcase className="h-4 w-4 mr-2" />
-                          My Skills
-                        </Button>
-                      </DialogTrigger>
-                      <DialogContent className="max-w-lg">
-                        <DialogHeader>
-                          <DialogTitle className="flex items-center gap-2">
-                            <Briefcase className="h-5 w-5" />
-                            {profile.name || profile.username}'s Skills
-                          </DialogTitle>
-                        </DialogHeader>
-                        {skills.length > 0 ? (
-                          <div className="space-y-3 max-h-80 overflow-y-auto">
-                            {skills.map((skill, idx) => {
-                              const skillName =
-                                typeof skill === "string"
-                                  ? skill
-                                  : skill.skill || skill.name;
-                              const level =
-                                typeof skill === "string" ? undefined : skill.level;
-                              const description =
-                                typeof skill === "string"
-                                  ? undefined
-                                  : skill.description;
-                              const years =
-                                typeof skill === "string"
-                                  ? undefined
-                                  : skill.yearsOfExperience;
-                              return (
-                                <div
-                                  key={skill.id || skillName || idx}
-                                  className="p-3 rounded-lg border bg-gray-50 border-gray-200"
-                                >
-                                  <div className="flex items-center justify-between mb-2">
-                                    <h5 className="font-medium">{skillName}</h5>
-                                    {level && (
-                                      <Badge variant="secondary" className="text-xs">
-                                        Level {level}
-                                      </Badge>
-                                    )}
-                                  </div>
-                                  {description && (
-                                    <p className="text-sm text-gray-600 mb-1">{description}</p>
-                                  )}
-                                  {years && (
-                                    <p className="text-xs text-gray-500">{years} years experience</p>
+                <div className="mb-4">
+                  <Dialog>
+                    <DialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full hover:bg-blue-50 border-blue-200"
+                      >
+                        <Briefcase className="h-4 w-4 mr-2" />
+                        My Skills
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent className="max-w-lg">
+                      <DialogHeader>
+                        <DialogTitle className="flex items-center gap-2">
+                          <Briefcase className="h-5 w-5" />
+                          {profile.name || profile.username}'s Skills
+                        </DialogTitle>
+                      </DialogHeader>
+                      {skills.length > 0 ? (
+                        <div className="space-y-3 max-h-80 overflow-y-auto">
+                          {skills.map((skill, idx) => {
+                            const skillName =
+                              typeof skill === "string"
+                                ? skill
+                                : skill.skill || skill.name;
+                            const level =
+                              typeof skill === "string" ? undefined : skill.level;
+                            const description =
+                              typeof skill === "string"
+                                ? undefined
+                                : skill.description;
+                            const years =
+                              typeof skill === "string"
+                                ? undefined
+                                : skill.yearsOfExperience;
+                            return (
+                              <div
+                                key={skill.id || skillName || idx}
+                                className="p-3 rounded-lg border bg-gray-50 border-gray-200"
+                              >
+                                <div className="flex items-center justify-between mb-2">
+                                  <h5 className="font-medium">{skillName}</h5>
+                                  {level && (
+                                    <Badge variant="secondary" className="text-xs">
+                                      Level {level}
+                                    </Badge>
                                   )}
                                 </div>
-                              );
-                            })}
-                          </div>
-                        ) : (
-                          <p className="text-sm text-gray-600">No skills added yet.</p>
-                        )}
-                      </DialogContent>
-                    </Dialog>
-                  </div>
-                )}
+                                {description && (
+                                  <p className="text-sm text-gray-600 mb-1">{description}</p>
+                                )}
+                                {years && (
+                                  <p className="text-xs text-gray-500">{years} years experience</p>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-gray-600">No skills added yet.</p>
+                      )}
+                    </DialogContent>
+                  </Dialog>
+                </div>
 
                 {/* Collaboration Request Button */}
                 <Dialog open={showCollaborationDialog} onOpenChange={setShowCollaborationDialog}>

--- a/client/src/pages/visitor-profile-new.tsx
+++ b/client/src/pages/visitor-profile-new.tsx
@@ -1155,12 +1155,12 @@ export default function VisitorProfileNew() {
                   <div className="mb-4">
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button 
-                          variant="outline" 
+                        <Button
+                          variant="outline"
                           className="w-full hover:bg-blue-50 border-blue-200"
                         >
                           <Briefcase className="h-4 w-4 mr-2" />
-                          Visit My Skills
+                          My Skills
                         </Button>
                       </DialogTrigger>
                       <DialogContent className="max-w-lg">
@@ -1170,26 +1170,49 @@ export default function VisitorProfileNew() {
                             {profile.name || profile.username}'s Skills
                           </DialogTitle>
                         </DialogHeader>
-                        <div className="space-y-3 max-h-80 overflow-y-auto">
-                          {skills.map((skill) => (
-                            <div key={skill.id} className="p-3 rounded-lg border bg-gray-50 border-gray-200">
-                              <div className="flex items-center justify-between mb-2">
-                                <h5 className="font-medium">{skill.skill || skill.name}</h5>
-                                <Badge variant="secondary" className="text-xs">
-                                  Level {skill.level}
-                                </Badge>
-                              </div>
-                              {skill.description && (
-                                <p className="text-sm text-gray-600 mb-1">{skill.description}</p>
-                              )}
-                              {skill.yearsOfExperience && (
-                                <p className="text-xs text-gray-500">
-                                  {skill.yearsOfExperience} years experience
-                                </p>
-                              )}
-                            </div>
-                          ))}
-                        </div>
+                        {skills.length > 0 ? (
+                          <div className="space-y-3 max-h-80 overflow-y-auto">
+                            {skills.map((skill, idx) => {
+                              const skillName =
+                                typeof skill === "string"
+                                  ? skill
+                                  : skill.skill || skill.name;
+                              const level =
+                                typeof skill === "string" ? undefined : skill.level;
+                              const description =
+                                typeof skill === "string"
+                                  ? undefined
+                                  : skill.description;
+                              const years =
+                                typeof skill === "string"
+                                  ? undefined
+                                  : skill.yearsOfExperience;
+                              return (
+                                <div
+                                  key={skill.id || skillName || idx}
+                                  className="p-3 rounded-lg border bg-gray-50 border-gray-200"
+                                >
+                                  <div className="flex items-center justify-between mb-2">
+                                    <h5 className="font-medium">{skillName}</h5>
+                                    {level && (
+                                      <Badge variant="secondary" className="text-xs">
+                                        Level {level}
+                                      </Badge>
+                                    )}
+                                  </div>
+                                  {description && (
+                                    <p className="text-sm text-gray-600 mb-1">{description}</p>
+                                  )}
+                                  {years && (
+                                    <p className="text-xs text-gray-500">{years} years experience</p>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        ) : (
+                          <p className="text-sm text-gray-600">No skills added yet.</p>
+                        )}
                       </DialogContent>
                     </Dialog>
                   </div>

--- a/migrations/0003_create_user_skills.sql
+++ b/migrations/0003_create_user_skills.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS user_skills (
+  id SERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  skill VARCHAR(255) NOT NULL,
+  level INTEGER NOT NULL DEFAULT 3,
+  description TEXT,
+  years_of_experience INTEGER,
+  CONSTRAINT user_skills_user_skill_unique UNIQUE (user_id, skill)
+);
+
+CREATE INDEX IF NOT EXISTS user_skills_user_id_idx ON user_skills(user_id);

--- a/server/db-storage-enhanced.ts
+++ b/server/db-storage-enhanced.ts
@@ -1045,9 +1045,16 @@ export class EnhancedDatabaseStorage implements IStorage {
   async getSkills(userId: number): Promise<any[]> {
     try {
       const rows = await db.execute(
-        sql`select skill from user_skills where user_id = ${userId} order by level desc`
+        sql`select id, skill, level, description, years_of_experience from user_skills where user_id = ${userId} order by level desc`
       );
-      const skills = (rows?.rows ?? []).map((r: any) => r.skill).filter(Boolean);
+      const skills = (rows?.rows ?? []).map((r: any) => ({
+        id: r.id,
+        name: r.skill,
+        skill: r.skill,
+        level: r.level,
+        description: r.description,
+        yearsOfExperience: r.years_of_experience,
+      }));
       return skills;
     } catch (error) {
       console.error("Error fetching skills:", error);

--- a/server/db-storage-enhanced.ts
+++ b/server/db-storage-enhanced.ts
@@ -1042,7 +1042,22 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   // Skills Management
+  private async ensureUserSkillsTable() {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS user_skills (
+        id SERIAL PRIMARY KEY,
+        user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        skill VARCHAR(255) NOT NULL,
+        level INTEGER NOT NULL DEFAULT 3,
+        description TEXT,
+        years_of_experience INTEGER,
+        CONSTRAINT user_skills_user_skill_unique UNIQUE (user_id, skill)
+      )
+    `);
+  }
+
   async getSkills(userId: string): Promise<any[]> {
+    await this.ensureUserSkillsTable();
     try {
       const rows = await db.execute(
         sql`select id, skill, level, description, years_of_experience from user_skills where user_id = ${userId} order by level desc`
@@ -1876,6 +1891,7 @@ export class EnhancedDatabaseStorage implements IStorage {
 
   // Skills methods that are missing
   async addUserSkill(userId: string, skill: string, level: number = 3): Promise<any> {
+    await this.ensureUserSkillsTable();
     const result = await db.execute(
       sql`INSERT INTO user_skills (user_id, skill, level)
           VALUES (${userId}, ${skill}, ${level})
@@ -1886,6 +1902,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   async updateUserSkill(skillId: string, updates: any): Promise<any> {
+    await this.ensureUserSkillsTable();
     const { skill, level, description, yearsOfExperience } = updates;
     const result = await db.execute(
       sql`UPDATE user_skills SET
@@ -1900,6 +1917,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   async deleteUserSkill(skillId: string): Promise<boolean> {
+    await this.ensureUserSkillsTable();
     const result = await db.execute(sql`DELETE FROM user_skills WHERE id = ${skillId}`);
     return result.rowCount ? result.rowCount > 0 : false;
   }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1078,7 +1078,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     // Don't include password in the response
     const { password, ...userWithoutPassword } = user;
 
-    res.json(userWithoutPassword);
+    // Include the user's skills for persistence across refreshes
+    const skills = await storage.getSkills(userId);
+
+    res.json({ ...userWithoutPassword, skills });
   }));
 
   app.patch("/api/profile", isAuthenticated, asyncHandler(async (req: any, res: any) => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1740,7 +1740,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
     // Use storage method if available, otherwise fallback to direct query
     if (typeof storage.addUserSkill === 'function') {
-      const newSkill = await storage.addUserSkill(userId, skill.trim());
+      const newSkill = await storage.addUserSkill(userId, skill.trim(), level);
       res.status(201).json(newSkill);
     } else {
       // Fallback to direct database query
@@ -1761,7 +1761,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
 
     if (typeof storage.updateUserSkill === 'function') {
-      const updatedSkill = await storage.updateUserSkill(skillId, { skill: skill.trim() });
+      const updatedSkill = await storage.updateUserSkill(skillId, { skill: skill.trim(), level });
       if (!updatedSkill) {
         return res.status(404).json({ message: "Skill not found or you don't have permission to update it" });
       }


### PR DESCRIPTION
## Summary
- add "My Skills" button to profile Connect & Collaborate card with popup listing user skills
- expose skills with id and level from user_skills table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS errors in existing source files)*

------
https://chatgpt.com/codex/tasks/task_e_68aef5855db8832c9329e335f786c50d