### PR TITLE
Persist tour completion state

### DIFF
--- a/client/src/hooks/use-tour.tsx
+++ b/client/src/hooks/use-tour.tsx
@@ -7,19 +7,26 @@ export function useTour() {
   const [tourCompleted, setTourCompleted] = useState(false);
 
   useEffect(() => {
-    if (user && !tourCompleted) {
-      // Check if user has completed tour before
-      const tourKey = `tour_completed_${user.id}`;
-      const hasCompletedTour = localStorage.getItem(tourKey) === 'true';
-      
-      if (!hasCompletedTour) {
-        // Show tour after a brief delay to let the page load
-        const timer = setTimeout(() => {
-          setShowTour(true);
-        }, 1500);
-        
-        return () => clearTimeout(timer);
+    if (!user) return;
+
+    const tourKey = `tour_completed_${user.id}`;
+    const hasCompletedTour = localStorage.getItem(tourKey) === 'true';
+
+    if (hasCompletedTour) {
+      // Persist completion state across sessions
+      if (!tourCompleted) {
+        setTourCompleted(true);
       }
+      return;
+    }
+
+    if (!tourCompleted) {
+      // Show tour after a brief delay to let the page load
+      const timer = setTimeout(() => {
+        setShowTour(true);
+      }, 1500);
+
+      return () => clearTimeout(timer);
     }
   }, [user, tourCompleted]);
 


### PR DESCRIPTION
## Summary
- persist tour completion across sessions by reading localStorage when auth state loads

## Testing
- `npm test` *(fails: tsx: not found)*
- `npm install` *(fails: 403 Forbidden for @types/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68afe9047b38832c839e2738aa6b4f5a