### PR TITLE
feat: add configurable Google OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Base URL of the application
+# Local development
+PUBLIC_BASE_URL=http://localhost:3000
+
+# Render deployment (set in Render dashboard)
+# PUBLIC_BASE_URL=https://your-render-domain
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+# Optional override for callback path
+# GOOGLE_CALLBACK_PATH=/auth/google/callback

--- a/docs/google-oauth.md
+++ b/docs/google-oauth.md
@@ -1,0 +1,29 @@
+# Google OAuth Setup
+
+To enable Google sign-in locally and on Render:
+
+## Environment Variables
+
+Set the following variables either in a local `.env` file or in the Render dashboard.
+
+```
+PUBLIC_BASE_URL=http://localhost:3000        # local development
+# PUBLIC_BASE_URL=https://your-render-domain  # Render (no trailing slash)
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+# GOOGLE_CALLBACK_PATH=/auth/google/callback  # optional override
+```
+
+## Google Cloud Console
+
+1. Navigate to **APIs & Services → Credentials**.
+2. Create or edit your OAuth 2.0 Client ID.
+3. Add the following:
+   - **Authorized JavaScript origins**
+     - `http://localhost:3000`
+     - `https://your-render-domain`
+   - **Authorized redirect URIs**
+     - `http://localhost:3000/auth/google/callback`
+     - `https://your-render-domain/auth/google/callback`
+
+Ensure the scheme, host, and path match exactly.

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "openai": "^4.104.0",
     "openid-client": "^6.6.2",
     "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,6 +55,7 @@ import emailRouter from "./email-routes";
 import supportRouter from "./support-routes";
 import { setupTikTokOAuth } from "./tiktok-oauth";
 import { sendPasswordResetEmail } from "./email-service";
+import authRouter from "../src/routes/auth";
 
 // Error handling middleware
 const asyncHandler = (fn: Function) => (req: any, res: any, next: any) => {
@@ -198,6 +199,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
     next();
   });
+
+  // Google OAuth routes
+  app.use(authRouter);
 
   app.use("/api/links", linksRouter);
 

--- a/src/auth/googleStrategy.ts
+++ b/src/auth/googleStrategy.ts
@@ -1,0 +1,33 @@
+import passport from 'passport';
+import { Strategy as GoogleStrategy, Profile } from 'passport-google-oauth20';
+import { GOOGLE_CALLBACK_URL } from '../config/url';
+import { storage } from '../../server/storage';
+
+passport.use(
+  new GoogleStrategy(
+    {
+      clientID: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      callbackURL: GOOGLE_CALLBACK_URL,
+    },
+    async (_accessToken, _refreshToken, profile: Profile, done) => {
+      try {
+        const email = profile.emails?.[0]?.value;
+        let user = email ? await storage.getUserByEmail(email) : undefined;
+        if (!user) {
+          user = await storage.createUser({
+            username: email || profile.id,
+            email: email || null,
+            name: profile.displayName || '',
+            password: '',
+          } as any);
+        }
+        return done(null, user as any);
+      } catch (err) {
+        return done(err as any);
+      }
+    }
+  )
+);
+
+export default passport;

--- a/src/config/url.ts
+++ b/src/config/url.ts
@@ -1,0 +1,11 @@
+export const PUBLIC_BASE_URL =
+  process.env.PUBLIC_BASE_URL ||
+  process.env.RENDER_EXTERNAL_URL ||
+  `http://localhost:${process.env.PORT || 3000}`;
+
+export const GOOGLE_CALLBACK_PATH =
+  process.env.GOOGLE_CALLBACK_PATH || '/auth/google/callback';
+
+export const GOOGLE_CALLBACK_URL = `${PUBLIC_BASE_URL}${GOOGLE_CALLBACK_PATH}`;
+
+console.log('[OAuth] GOOGLE_CALLBACK_URL:', GOOGLE_CALLBACK_URL);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import passport from 'passport';
+import { GOOGLE_CALLBACK_PATH, GOOGLE_CALLBACK_URL } from '../config/url';
+import '../auth/googleStrategy';
+
+const router = express.Router();
+
+router.get('/auth/google', (req, res, next) => {
+  console.log('[OAuth] start → redirectUri:', GOOGLE_CALLBACK_URL);
+  passport.authenticate('google', { scope: ['profile', 'email'] })(req, res, next);
+});
+
+router.get(GOOGLE_CALLBACK_PATH, (req, res, next) => {
+  passport.authenticate('google', { failureRedirect: '/login?oauth=google_failed' })(
+    req,
+    res,
+    () => res.redirect('/dashboard')
+  );
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add configurable PUBLIC_BASE_URL and Google callback URL
- implement Google OAuth strategy and routes
- document Google OAuth setup and environment variables

## Testing
- ⚠️ `npm test` *(tsx not found; dependencies not installed due to npm 403)*

------
https://chatgpt.com/codex/tasks/task_e_68afee3e6b08832cb6d1784b38d80ec9