### PR TITLE
feat: re-enable smart link ai on dashboard

### DIFF
--- a/client/src/pages/ai-enhanced-dashboard.tsx
+++ b/client/src/pages/ai-enhanced-dashboard.tsx
@@ -2525,13 +2525,10 @@ export default function AIEnhancedDashboard() {
 
             {/* Right Column - Smart Link AI and One-Click Pitch Mode (1 column) */}
             <div className="md:col-span-1 space-y-6">
-              {/* Smart Link AI Component temporarily disabled */}
-              {false && (
-                <SmartLinkAI
-                  links={links || []}
-                  onApplySuggestions={handleApplySuggestions}
-                />
-              )}
+              <SmartLinkAI
+                links={links || []}
+                onApplySuggestions={handleApplySuggestions}
+              />
 
               {/* One-Click Pitch Mode Card */}
               <PitchModeCard />


### PR DESCRIPTION
## Summary
- restore Smart Link AI section to dashboard right column
- ensure component uses existing mock analysis and suggestion API

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: multiple TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0542f918c832c93f1965dbc7b59ca