### PR TITLE
Fix referral request submission validation

### DIFF
--- a/client/src/pages/visitor-profile-new.tsx
+++ b/client/src/pages/visitor-profile-new.tsx
@@ -330,10 +330,18 @@ export default function VisitorProfileNew() {
     console.log('Form data:', referralForm);
 
     // Validation
-    if (!referralForm.name || !referralForm.email || !referralForm.fieldOfWork || !referralForm.linkTitle || !referralForm.linkUrl) {
+    if (
+      !referralForm.name ||
+      !referralForm.email ||
+      !referralForm.fieldOfWork ||
+      !referralForm.description ||
+      !referralForm.linkTitle ||
+      !referralForm.linkUrl
+    ) {
       toast({
         title: "Missing required fields",
-        description: "Please fill in your name, email, field of work, link title, and link URL.",
+        description:
+          "Please fill in your name, email, field of work, description, link title, and link URL.",
         variant: "destructive",
       });
       return;

--- a/client/src/pages/visitor-profile-working.tsx
+++ b/client/src/pages/visitor-profile-working.tsx
@@ -126,8 +126,15 @@ export default function VisitorProfileWorking() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          ...referralForm,
-          profileUserId: parseInt(data?.profile.id, 10)
+          requesterName: referralForm.name,
+          requesterEmail: referralForm.email,
+          requesterPhone: referralForm.phone,
+          requesterWebsite: referralForm.website,
+          fieldOfWork: referralForm.fieldOfWork,
+          description: referralForm.description,
+          linkTitle: referralForm.linkTitle,
+          linkUrl: referralForm.linkUrl,
+          targetUserId: parseInt(data?.profile.id, 10)
         }),
       });
 


### PR DESCRIPTION
## Summary
- Map visitor referral request fields to API expected names and include target user id
- Require description field in visitor referral form

## Testing
- `npm test` *(fails: tsx: not found)*
- `npm install tsx` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0559d98e8832cbbf22517dd9e5967