### PR TITLE
fix: use correct user id when submitting referral requests

### DIFF
--- a/client/src/pages/visitor-profile-new.tsx
+++ b/client/src/pages/visitor-profile-new.tsx
@@ -357,7 +357,7 @@ export default function VisitorProfileNew() {
         description: referralForm.description,
         linkTitle: referralForm.linkTitle,
         linkUrl: referralForm.linkUrl,
-        targetUserId: parseInt(data?.profile.id, 10)
+        targetUserId: data?.profile.id
       };
 
       console.log('Sending request data:', requestData);

--- a/client/src/pages/visitor-profile-working.tsx
+++ b/client/src/pages/visitor-profile-working.tsx
@@ -134,7 +134,7 @@ export default function VisitorProfileWorking() {
           description: referralForm.description,
           linkTitle: referralForm.linkTitle,
           linkUrl: referralForm.linkUrl,
-          targetUserId: parseInt(data?.profile.id, 10)
+          targetUserId: data?.profile.id
         }),
       });
 


### PR DESCRIPTION
## Summary
- ensure referral requests send user UUID instead of parsing as number
- avoid converting user IDs to integers in visitor profile referral forms

## Testing
- `npm test` *(fails: tsx not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0da61ca04832c8c187a3002a7b343