### PR TITLE
chore(db): add referral_requests migration and migration runner

### DIFF
--- a/migrations/02-create-referral-requests-table.sql
+++ b/migrations/02-create-referral-requests-table.sql
@@ -1,0 +1,21 @@
+-- 02-create-referral-requests-table.sql
+-- Create the referral_requests table for referral link requests
+CREATE TABLE IF NOT EXISTS referral_requests (
+  id SERIAL PRIMARY KEY,
+  target_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  requester_name VARCHAR(100) NOT NULL,
+  requester_email VARCHAR(255) NOT NULL,
+  requester_phone VARCHAR(50),
+  requester_website VARCHAR(500),
+  field_of_work VARCHAR(100),
+  description TEXT,
+  link_title VARCHAR(100),
+  link_url VARCHAR(500),
+  status VARCHAR(20) DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Index to quickly find pending requests for a user
+CREATE INDEX IF NOT EXISTS idx_referral_requests_target_user
+  ON referral_requests(target_user_id);

--- a/run-migrations.mjs
+++ b/run-migrations.mjs
@@ -1,5 +1,3 @@
-# 1) Create the file
-cat > run-migrations.mjs <<'EOF'
 // run-migrations.mjs
 import { Pool } from 'pg';
 import fs from 'fs';
@@ -19,7 +17,6 @@ async function runMigration() {
 
   try {
     const migrationsDir = path.join(__dirname, 'migrations');
-
     const files = fs
       .readdirSync(migrationsDir)
       .filter((f) => f.endsWith('.sql'))
@@ -35,13 +32,11 @@ async function runMigration() {
     console.log('-'.repeat(80));
 
     await pool.query('BEGIN');
-
     for (const file of files) {
       const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
       console.log(`Applying ${file} ...`);
       await pool.query(sql);
     }
-
     await pool.query('COMMIT');
     console.log('-'.repeat(80));
     console.log('All migrations applied successfully!');
@@ -58,9 +53,3 @@ runMigration().catch((err) => {
   console.error('Unhandled error:', err);
   process.exit(1);
 });
-EOF
-
-# 2) Add, commit, push
-git add run-migrations.mjs
-git commit -m "Add run-migrations.mjs and wire migrations to start"
-git push


### PR DESCRIPTION
## Summary
- add SQL migration to create `referral_requests` table and index
- add migration runner script to apply `.sql` files sequentially

## Testing
- `npm test` *(fails: sh: 1: tsx: not found)*
- `npm run check` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e6d95d80832c8e5ff0f43ed74b30