### PR TITLE
fix(referrals): send UUID string from client; accept camelCase on server and insert row

### DIFF
--- a/client/src/pages/visitor-profile-new.tsx
+++ b/client/src/pages/visitor-profile-new.tsx
@@ -349,15 +349,16 @@ export default function VisitorProfileNew() {
 
     try {
       const requestData = {
-        requesterName: referralForm.name,
-        requesterEmail: referralForm.email,
-        requesterPhone: referralForm.phone,
-        requesterWebsite: referralForm.website,
-        fieldOfWork: referralForm.fieldOfWork,
-        description: referralForm.description,
-        linkTitle: referralForm.linkTitle,
-        linkUrl: referralForm.linkUrl,
-        targetUserId: parseInt(data?.profile.id, 10)
+        requesterName: referralForm.name?.trim(),
+        requesterEmail: referralForm.email?.trim(),
+        requesterPhone: referralForm.phone?.trim() || null,
+        requesterWebsite: referralForm.website?.trim() || null,
+        fieldOfWork: referralForm.fieldOfWork?.trim(),
+        description: referralForm.description?.trim() || null,
+        linkTitle: referralForm.linkTitle?.trim(),
+        linkUrl: referralForm.linkUrl?.trim(),
+        // IMPORTANT: do NOT parseInt — IDs are UUID strings
+        targetUserId: data?.profile.id
       };
 
       console.log('Sending request data:', requestData);

--- a/client/src/pages/visitor-profile-working.tsx
+++ b/client/src/pages/visitor-profile-working.tsx
@@ -120,22 +120,23 @@ export default function VisitorProfileWorking() {
   // Form submission handlers
   const handleReferralSubmit = async () => {
     try {
+      const requestData = {
+        requesterName: referralForm.name?.trim(),
+        requesterEmail: referralForm.email?.trim(),
+        requesterPhone: referralForm.phone?.trim() || null,
+        requesterWebsite: referralForm.website?.trim() || null,
+        fieldOfWork: referralForm.fieldOfWork?.trim(),
+        description: referralForm.description?.trim() || null,
+        linkTitle: referralForm.linkTitle?.trim(),
+        linkUrl: referralForm.linkUrl?.trim(),
+        // IMPORTANT: do NOT parseInt — IDs are UUID strings
+        targetUserId: data?.profile.id
+      };
+
       const response = await fetch('/api/referral-requests', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          requesterName: referralForm.name,
-          requesterEmail: referralForm.email,
-          requesterPhone: referralForm.phone,
-          requesterWebsite: referralForm.website,
-          fieldOfWork: referralForm.fieldOfWork,
-          description: referralForm.description,
-          linkTitle: referralForm.linkTitle,
-          linkUrl: referralForm.linkUrl,
-          targetUserId: parseInt(data?.profile.id, 10)
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestData)
       });
 
       if (response.ok) {

--- a/migrations/02-create-referral-requests-table.sql
+++ b/migrations/02-create-referral-requests-table.sql
@@ -1,0 +1,21 @@
+-- 02-create-referral-requests-table.sql
+-- Create the referral_requests table for referral link requests
+CREATE TABLE IF NOT EXISTS referral_requests (
+  id SERIAL PRIMARY KEY,
+  target_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  requester_name VARCHAR(100) NOT NULL,
+  requester_email VARCHAR(255) NOT NULL,
+  requester_phone VARCHAR(50),
+  requester_website VARCHAR(500),
+  field_of_work VARCHAR(100),
+  description TEXT,
+  link_title VARCHAR(100),
+  link_url VARCHAR(500),
+  status VARCHAR(20) DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Index to quickly find pending requests for a user
+CREATE INDEX IF NOT EXISTS idx_referral_requests_target_user
+  ON referral_requests(target_user_id);

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import { migrate } from "drizzle-orm/neon-serverless/migrator";
 import { db } from "./db";
 import path from "path";
 import { fileURLToPath } from "url";
+import referralRequestsRouter from './routes/referral-requests';
 // Temporarily disabled problematic imports
 // import { initializeEmailTemplates } from "./init-email-templates";
 // import { initAIEmailTemplates } from "./ai-email-templates";
@@ -78,6 +79,8 @@ app.use(session({
   },
   // TODO: move to a persistent store later; MemoryStore is OK short-term
 }));
+
+app.use(referralRequestsRouter);
 
 app.get("/healthz", (_req, res) => res.status(200).send("ok"));
 

--- a/server/routes/referral-requests.ts
+++ b/server/routes/referral-requests.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { db } from '../db';
+import { sql } from 'drizzle-orm';
+
+const router = Router();
+
+const Schema = z.object({
+  targetUserId: z.string().min(1),
+  requesterName: z.string().min(1),
+  requesterEmail: z.string().email(),
+  requesterPhone: z.string().nullable().optional(),
+  requesterWebsite: z.string().url().nullable().optional(),
+  fieldOfWork: z.string().min(1),
+  description: z.string().nullable().optional(),
+  linkTitle: z.string().min(1),
+  linkUrl: z.string().min(1)
+});
+
+router.post('/api/referral-requests', async (req, res, next) => {
+  try {
+    if (!req.user?.id) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const parsed = Schema.safeParse(req.body);
+    if (!parsed.success) {
+      console.log('Invalid referral request', req.body, parsed.error.issues);
+      return res.status(400).json({ message: 'Missing required fields', details: parsed.error.issues });
+    }
+    const p = parsed.data;
+
+    const row = {
+      target_user_id: p.targetUserId,
+      requester_name: p.requesterName,
+      requester_email: p.requesterEmail,
+      requester_phone: p.requesterPhone ?? null,
+      requester_website: p.requesterWebsite ?? null,
+      field_of_work: p.fieldOfWork,
+      description: p.description ?? null,
+      link_title: p.linkTitle,
+      link_url: p.linkUrl,
+      status: 'pending'
+    };
+
+    await db.execute(sql`
+      INSERT INTO referral_requests (
+        target_user_id, requester_name, requester_email, requester_phone,
+        requester_website, field_of_work, description, link_title, link_url, status
+      ) VALUES (
+        ${row.target_user_id}, ${row.requester_name}, ${row.requester_email}, ${row.requester_phone},
+        ${row.requester_website}, ${row.field_of_work}, ${row.description}, ${row.link_title}, ${row.link_url}, ${row.status}
+      )
+    `);
+
+    return res.status(201).json({ message: 'Referral request submitted' });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- send referral requests with trimmed fields and raw UUIDs from visitor profile pages
- add `/api/referral-requests` route to validate camelCase payload and insert into `referral_requests`
- register referral request router in express server

## Testing
- `npm test` *(fails: tsx: not found)*
- `npm run check` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e6d95d80832c8e5ff0f43ed74b30