### PR TITLE
Fix dashboard notifications missing after login

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -127,6 +127,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     onSuccess: (user: User) => {
       console.log("Login successful:", user);
       queryClient.setQueryData(["/api/user"], user);
+      // Invalidate notifications so they load immediately after login
+      queryClient.invalidateQueries({ queryKey: ["/api/notifications"] });
       toast.toast({
         title: "Login successful",
         description: `Welcome back, ${user.name}!`,
@@ -164,6 +166,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     onSuccess: (user: User) => {
       console.log("Registration successful:", user);
       queryClient.setQueryData(["/api/user"], user);
+      // Clear notifications cache in case any exist from a previous session
+      queryClient.invalidateQueries({ queryKey: ["/api/notifications"] });
       toast.toast({
         title: "Registration successful",
         description: `Welcome to MyLinked, ${user.name}!`,


### PR DESCRIPTION
## Summary
- Invalidate `/api/notifications` query after login or registration so the dashboard shows new notifications without needing a manual refresh

## Testing
- `npm test` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b387dcd770832ca8142f997cbf559d