### PR TITLE
Add forgot password link to admin login

### DIFF
--- a/client/src/pages/admin-login.tsx
+++ b/client/src/pages/admin-login.tsx
@@ -148,6 +148,18 @@ export default function AdminLogin() {
                 </>
               )}
             </Button>
+
+            <div className="text-center mt-4">
+              <Button
+                type="button"
+                variant="link"
+                className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
+                onClick={() => setLocation("/forgot-password")}
+                disabled={loginMutation.isPending}
+              >
+                Forgot your password?
+              </Button>
+            </div>
           </form>
           
           <div className="mt-6 pt-6 border-t text-center text-sm text-slate-500">


### PR DESCRIPTION
## Summary
- add a "Forgot your password?" link to the admin login screen for account recovery

## Testing
- `npm test` *(fails: tsx not found, dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b38f331428832cba8e32a09fe9dca4