### PR TITLE
feat: add one-off admin reset script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "migrate": "node run-migrations.mjs"
+    "migrate": "node run-migrations.mjs",
+    "admin:reset": "tsx scripts/admin-reset.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/admin-reset.ts
+++ b/scripts/admin-reset.ts
@@ -1,0 +1,93 @@
+/**
+ * One-off admin password reset or creation script.
+ *
+ * Usage:
+ *   ADMIN_USERNAME=admin ADMIN_NEW_PASSWORD='Strong.P@ssw0rd' npm run admin:reset
+ *   npm run admin:reset -- --username admin --password 'Strong.P@ssw0rd' [--email admin@example.com]
+ *
+ * Deploy temporarily on Render with:
+ *   ADMIN_USERNAME=admin ADMIN_NEW_PASSWORD=Strong.P@ssw0rd npm run admin:reset && npm run start
+ * After confirming success, remove the env vars and this script.
+ */
+
+import { db } from "../server/db";
+import { users } from "../shared/schema";
+import { eq } from "drizzle-orm";
+import { hashPassword } from "../server/auth";
+import { getUserColumnSet } from "../server/user-columns";
+import { randomUUID } from "crypto";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if ((arg === "--username" || arg === "-u") && args[i + 1]) {
+      out.username = args[++i];
+    } else if ((arg === "--password" || arg === "-p") && args[i + 1]) {
+      out.password = args[++i];
+    } else if ((arg === "--email" || arg === "-e") && args[i + 1]) {
+      out.email = args[++i];
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const flags = parseArgs();
+  const username = flags.username || process.env.ADMIN_USERNAME;
+  const password = flags.password || process.env.ADMIN_NEW_PASSWORD;
+  const email = flags.email || process.env.ADMIN_EMAIL;
+
+  if (!username || !password) {
+    console.error("ADMIN_USERNAME and ADMIN_NEW_PASSWORD (or --username/--password) are required");
+    process.exit(1);
+  }
+
+  const columnSet = await getUserColumnSet(db);
+  if (!columnSet.has("password")) {
+    console.error("users table missing password column");
+    process.exit(1);
+  }
+
+  const hashed = await hashPassword(password);
+
+  const existing = await db
+    .select()
+    .from(users)
+    .where(eq(users.username, username))
+    .limit(1);
+
+  if (existing.length) {
+    const user = existing[0];
+    const updates: any = { password: hashed, updatedAt: new Date() };
+    if (email && columnSet.has("email")) updates.email = email;
+    if (columnSet.has("is_admin")) updates.isAdmin = true;
+    if (columnSet.has("role")) updates.role = "admin";
+    if (columnSet.has("is_active")) updates.isActive = true;
+
+    await db.update(users).set(updates).where(eq(users.id, user.id));
+    console.log(`Admin password updated for user '${username}'`);
+  } else {
+    const insert: any = {
+      id: randomUUID(),
+      username,
+      name: username,
+      password: hashed,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    if (email && columnSet.has("email")) insert.email = email;
+    if (columnSet.has("is_admin")) insert.isAdmin = true;
+    if (columnSet.has("role")) insert.role = "admin";
+    if (columnSet.has("is_active")) insert.isActive = true;
+
+    await db.insert(users).values(insert);
+    console.log(`Admin user '${username}' created`);
+  }
+}
+
+main().then(() => process.exit(0)).catch(err => {
+  console.error("Failed to reset admin password:", err);
+  process.exit(1);
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { db } from "./db";
 import path from "path";
 import { fileURLToPath } from "url";
 import referralRequestsRouter from "./routes/referral-requests";
+// import adminResetRoute from "./routes/internal-admin-reset"; // WARNING: enable only for one-time admin recovery
 // Temporarily disabled problematic imports
 // import { initializeEmailTemplates } from "./init-email-templates";
 // import { initAIEmailTemplates } from "./ai-email-templates";
@@ -148,6 +149,7 @@ app.use((req, res, next) => {
   const server = await registerRoutes(app);
 
   app.use(referralRequestsRouter);
+  // app.use(adminResetRoute); // WARNING: remove after use. Requires ADMIN_RECOVERY_TOKEN and x-admin-recovery-token header.
 
   // Add custom domain route handler AFTER API routes are registered
   app.get('*', (req, res, next) => {

--- a/server/routes/internal-admin-reset.ts
+++ b/server/routes/internal-admin-reset.ts
@@ -1,0 +1,74 @@
+/**
+ * WARNING: This internal route is disabled by default.
+ * Enable only for emergency admin password recovery when ADMIN_RECOVERY_TOKEN is set.
+ * The route self-disables after a single successful request.
+ */
+
+import { Router } from "express";
+import { db } from "../db";
+import { users } from "../shared/schema";
+import { eq } from "drizzle-orm";
+import { hashPassword } from "../auth";
+import { getUserColumnSet } from "../user-columns";
+import { randomUUID } from "crypto";
+
+const router = Router();
+let enabled = Boolean(process.env.ADMIN_RECOVERY_TOKEN);
+
+router.post("/internal/admin-reset", async (req, res) => {
+  if (!enabled) return res.status(404).end();
+
+  const token = req.get("x-admin-recovery-token");
+  if (!process.env.ADMIN_RECOVERY_TOKEN || token !== process.env.ADMIN_RECOVERY_TOKEN) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  const { username, password, email } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ message: "username and password required" });
+  }
+
+  const columnSet = await getUserColumnSet(db);
+  if (!columnSet.has("password")) {
+    return res.status(500).json({ message: "users table missing password column" });
+  }
+
+  const hashed = await hashPassword(password);
+
+  const existing = await db
+    .select()
+    .from(users)
+    .where(eq(users.username, username))
+    .limit(1);
+
+  if (existing.length) {
+    const user = existing[0];
+    const updates: any = { password: hashed, updatedAt: new Date() };
+    if (email && columnSet.has("email")) updates.email = email;
+    if (columnSet.has("is_admin")) updates.isAdmin = true;
+    if (columnSet.has("role")) updates.role = "admin";
+    if (columnSet.has("is_active")) updates.isActive = true;
+
+    await db.update(users).set(updates).where(eq(users.id, user.id));
+  } else {
+    const insert: any = {
+      id: randomUUID(),
+      username,
+      name: username,
+      password: hashed,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    if (email && columnSet.has("email")) insert.email = email;
+    if (columnSet.has("is_admin")) insert.isAdmin = true;
+    if (columnSet.has("role")) insert.role = "admin";
+    if (columnSet.has("is_active")) insert.isActive = true;
+
+    await db.insert(users).values(insert);
+  }
+
+  enabled = false; // self-disable after one use
+  return res.json({ message: `Admin password reset for '${username}'` });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add `admin:reset` CLI script to reset or create admin users
- document disabled internal reset route behind recovery token
- wire commented references so the route remains off by default

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: TypeScript errors in client pages)*

------
https://chatgpt.com/codex/tasks/task_e_68b43cf43ef4832c84d7a850b5446d3a