### PR TITLE
feat: add admin management scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "migrate": "node run-migrations.mjs"
+    "migrate": "node run-migrations.mjs",
+    "admins:list": "tsx scripts/print-admins.ts",
+    "admin:set-password": "tsx scripts/admin-set-password.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -76,6 +78,7 @@
     "openid-client": "^6.6.2",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
+    "pg": "^8.13.1",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",

--- a/scripts/admin-set-password.ts
+++ b/scripts/admin-set-password.ts
@@ -1,0 +1,59 @@
+/**
+ * Examples:
+ *   TARGET_USERNAME=Armintest NEW_PASSWORD='Strong.P@ssw0rd' npm run admin:set-password
+ *   npm run admin:set-password -- --username Armintest --password 'Strong.P@ssw0rd'
+ */
+import { Pool } from 'pg';
+import { hashPassword } from '../server/auth/password';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let username = process.env.TARGET_USERNAME;
+  let password = process.env.NEW_PASSWORD;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--username' || arg === '--user') {
+      username = args[++i];
+    } else if (arg === '--password' || arg === '--pass') {
+      password = args[++i];
+    }
+  }
+  return { username, password };
+}
+
+async function hasColumn(table: string, column: string): Promise<boolean> {
+  const res = await pool.query(
+    'SELECT 1 FROM information_schema.columns WHERE table_name=$1 AND column_name=$2',
+    [table, column]
+  );
+  return res.rowCount > 0;
+}
+
+async function main() {
+  const { username, password } = parseArgs();
+  if (!username || !password) {
+    console.error('Username and password are required');
+    process.exit(1);
+  }
+  try {
+    const usernameColumn = (await hasColumn('users', 'username')) ? 'username' : 'email';
+    const passwordColumn = (await hasColumn('users', 'password')) ? 'password' : 'password_hash';
+    const hashed = await hashPassword(password);
+    const query = `UPDATE users SET ${passwordColumn} = $1 WHERE ${usernameColumn} = $2`;
+    const { rowCount } = await pool.query(query, [hashed, username]);
+    if (rowCount === 0) {
+      console.error('User not found');
+      process.exit(1);
+    }
+    console.log(`Password updated for ${username}`);
+  } catch (err) {
+    console.error('Failed to set password:', err);
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+void main();

--- a/scripts/print-admins.ts
+++ b/scripts/print-admins.ts
@@ -1,0 +1,54 @@
+/**
+ * Example:
+ *   npm run admins:list
+ */
+import { Pool } from 'pg';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function hasColumn(table: string, column: string): Promise<boolean> {
+  const res = await pool.query(
+    'SELECT 1 FROM information_schema.columns WHERE table_name=$1 AND column_name=$2',
+    [table, column]
+  );
+  return res.rowCount > 0;
+}
+
+async function main() {
+  try {
+    const roleExists = await hasColumn('users', 'role');
+    const isAdminExists = await hasColumn('users', 'is_admin');
+    const usernameColumn = (await hasColumn('users', 'username')) ? 'username' : 'email';
+
+    const conditions: string[] = [];
+    const params: any[] = [];
+    if (roleExists) {
+      params.push('admin');
+      conditions.push(`role = $${params.length}`);
+    }
+    if (isAdminExists) {
+      params.push(true);
+      conditions.push(`is_admin = $${params.length}`);
+    }
+
+    if (conditions.length === 0) {
+      console.log('No admin columns found');
+      return;
+    }
+
+    const query = `SELECT id, ${usernameColumn} AS username, email, created_at FROM users WHERE ${conditions.join(' OR ')} LIMIT 100`;
+    const { rows } = await pool.query(query, params);
+
+    for (const row of rows) {
+      const created = row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at;
+      console.log(`${row.id}\t${row.username}\t${row.email}\t${created}`);
+    }
+  } catch (err) {
+    console.error('Failed to list admins:', err);
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+void main();

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -2,8 +2,7 @@ import { Express, Request, Response, NextFunction } from "express";
 import passport from "passport";
 import { Strategy as LocalStrategy } from "passport-local";
 import "express-session";
-import { scrypt, randomBytes, timingSafeEqual } from "crypto";
-import { promisify } from "util";
+import { hashPassword, comparePasswords } from "./auth/password";
 import { storage } from "./storage";
 import { User as UserType, users } from "../shared/schema";
 import { isDbAvailable, db } from "./db";
@@ -25,21 +24,7 @@ declare global {
   }
 }
 
-const scryptAsync = promisify(scrypt);
-
-export async function hashPassword(password: string) {
-  const salt = randomBytes(16).toString("hex");
-  const buf = (await scryptAsync(password, salt, 64)) as Buffer;
-  return `${buf.toString("hex")}.${salt}`;
-}
-
-export async function comparePasswords(supplied: string, stored: string) {
-  const [hashed, salt] = stored.split(".");
-  if (!hashed || !salt) return false;
-  const hashedBuf = Buffer.from(hashed, "hex");
-  const suppliedBuf = (await scryptAsync(supplied, salt, 64)) as Buffer;
-  return timingSafeEqual(hashedBuf, suppliedBuf);
-}
+export { hashPassword, comparePasswords } from "./auth/password";
 
 export function setupAuth(app: Express) {
   app.use(passport.initialize());

--- a/server/auth/password.ts
+++ b/server/auth/password.ts
@@ -1,0 +1,18 @@
+import { scrypt, randomBytes, timingSafeEqual } from 'crypto';
+import { promisify } from 'util';
+
+const scryptAsync = promisify(scrypt);
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16).toString('hex');
+  const buf = (await scryptAsync(password, salt, 64)) as Buffer;
+  return `${buf.toString('hex')}.${salt}`;
+}
+
+export async function comparePasswords(supplied: string, stored: string): Promise<boolean> {
+  const [hashed, salt] = stored.split('.');
+  if (!hashed || !salt) return false;
+  const hashedBuf = Buffer.from(hashed, 'hex');
+  const suppliedBuf = (await scryptAsync(supplied, salt, 64)) as Buffer;
+  return timingSafeEqual(hashedBuf, suppliedBuf);
+}


### PR DESCRIPTION
## Summary
- add script to print admin users
- add script to set a user's password
- share password hashing logic via auth utility

## Testing
- `npm test` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b45f8febc4832ca323e97c4ee4151a