### PR TITLE
feat(auth): permanent password reset (email tokens + owner HMAC recovery)

### DIFF
--- a/client/src/pages/forgot-password.tsx
+++ b/client/src/pages/forgot-password.tsx
@@ -1,181 +1,59 @@
-import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { useLocation } from "wouter";
-import { ArrowLeft, Mail } from "lucide-react";
-import { useMutation } from "@tanstack/react-query";
-import { apiRequest } from "@/lib/queryClient";
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
 
 const forgotPasswordSchema = z.object({
-  email: z.string().email("Please enter a valid email address"),
+  identifier: z.string().min(1, 'Email or username is required'),
 });
 
 type ForgotPasswordForm = z.infer<typeof forgotPasswordSchema>;
 
 export default function ForgotPasswordPage() {
-  const [, setLocation] = useLocation();
-  const [isSubmitted, setIsSubmitted] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
+  const { toast } = useToast();
   const form = useForm<ForgotPasswordForm>({
     resolver: zodResolver(forgotPasswordSchema),
-    defaultValues: {
-      email: "",
-    },
+    defaultValues: { identifier: '' },
   });
 
-  const forgotPasswordMutation = useMutation({
-    mutationFn: async (data: ForgotPasswordForm) => {
-      const response = await fetch("/api/forgot-password", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
-      });
-      
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || "Failed to send reset email");
-      }
-      
-      return response.json();
-    },
-    onSuccess: () => {
-      setIsSubmitted(true);
-      setErrorMessage(null);
-    },
-    onError: (error: any) => {
-      console.error("Forgot password error:", error);
-      setErrorMessage(error.message || "Failed to send reset email. Please try again.");
-    },
-  });
+  const onSubmit = async (data: ForgotPasswordForm) => {
+    const body = data.identifier.includes('@')
+      ? { email: data.identifier }
+      : { username: data.identifier };
 
-  const onSubmit = (data: ForgotPasswordForm) => {
-    setErrorMessage(null);
-    forgotPasswordMutation.mutate(data);
+    await fetch('/api/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    toast({ title: 'If your account exists, you will receive an email shortly.' });
   };
 
-  if (isSubmitted) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 dark:from-gray-900 dark:via-blue-900 dark:to-purple-900 flex items-center justify-center p-4">
-        <div className="w-full max-w-md">
-          <Card className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg shadow-xl border-white/20 dark:border-gray-700/50">
-            <CardHeader className="text-center space-y-4">
-              <div className="mx-auto w-16 h-16 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full flex items-center justify-center">
-                <Mail className="h-8 w-8 text-white" />
-              </div>
-              <CardTitle className="text-2xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-                Check Your Email
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-center space-y-6">
-              <p className="text-gray-600 dark:text-gray-300">
-                If an account with this email exists, you will receive a password reset link shortly.
-              </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Check your spam folder if you don't see the email in your inbox.
-              </p>
-              <Button
-                onClick={() => setLocation("/auth")}
-                className="w-full h-12 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-medium"
-              >
-                Back to Login
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 dark:from-gray-900 dark:via-blue-900 dark:to-purple-900 flex items-center justify-center p-4">
-      <div className="w-full max-w-md">
-        <Card className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg shadow-xl border-white/20 dark:border-gray-700/50">
-          <CardHeader className="text-center space-y-4">
-            {/* Logo */}
-            <div className="flex justify-center">
-              <img 
-                src="/assets/logo-horizontal.png" 
-                alt="MyLinked" 
-                className="h-12 object-contain"
-                onError={(e) => {
-                  (e.currentTarget as HTMLImageElement).style.display = 'none';
-                  (e.currentTarget.nextElementSibling as HTMLElement)!.style.display = 'block';
-                }}
-              />
-              <div 
-                className="text-2xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent hidden"
-              >
-                MyLinked
-              </div>
-            </div>
-            <CardTitle className="text-2xl font-bold text-gray-900 dark:text-white">
-              Forgot Password
-            </CardTitle>
-            <p className="text-gray-600 dark:text-gray-300">
-              Enter your email address and we'll send you a link to reset your password.
-            </p>
-          </CardHeader>
-
-          <CardContent>
-            {errorMessage && (
-              <Alert className="mb-6 border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800">
-                <AlertDescription className="text-red-800 dark:text-red-300">
-                  {errorMessage}
-                </AlertDescription>
-              </Alert>
+    <div className="p-4 max-w-md mx-auto">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="identifier"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email or Username</FormLabel>
+                <FormControl>
+                  <Input {...field} placeholder="you@example.com or username" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-
-            <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                <FormField
-                  control={form.control}
-                  name="email"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Email Address</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="email"
-                          placeholder="Enter your email address"
-                          {...field}
-                          autoComplete="email"
-                          className="h-12"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <Button
-                  type="submit"
-                  className="w-full h-12 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-medium"
-                  disabled={forgotPasswordMutation.isPending}
-                >
-                  {forgotPasswordMutation.isPending ? "Sending..." : "Send Reset Link"}
-                </Button>
-
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="w-full h-12 text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100"
-                  onClick={() => setLocation("/auth")}
-                >
-                  <ArrowLeft className="h-4 w-4 mr-2" />
-                  Back to Login
-                </Button>
-              </form>
-            </Form>
-          </CardContent>
-        </Card>
-      </div>
+          />
+          <Button type="submit" className="w-full">Send Reset Link</Button>
+        </form>
+      </Form>
     </div>
   );
 }

--- a/client/src/pages/reset-password.tsx
+++ b/client/src/pages/reset-password.tsx
@@ -1,329 +1,81 @@
-import React, { useState, useEffect } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { useLocation } from "wouter";
-import { ArrowLeft, Eye, EyeOff, CheckCircle } from "lucide-react";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { apiRequest } from "@/lib/queryClient";
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import { useLocation } from 'wouter';
 
-const resetPasswordSchema = z.object({
-  newPassword: z.string().min(6, "Password must be at least 6 characters"),
-  confirmPassword: z.string().min(6, "Password must be at least 6 characters"),
-}).refine((data) => data.newPassword === data.confirmPassword, {
+const schema = z.object({
+  password: z.string().min(6, 'Password must be at least 6 characters'),
+  confirm: z.string().min(6, 'Confirm your password'),
+}).refine((data) => data.password === data.confirm, {
   message: "Passwords don't match",
-  path: ["confirmPassword"],
+  path: ['confirm'],
 });
 
-type ResetPasswordForm = z.infer<typeof resetPasswordSchema>;
+type ResetForm = z.infer<typeof schema>;
 
 export default function ResetPasswordPage() {
+  const { toast } = useToast();
   const [, setLocation] = useLocation();
-  const [isSuccess, setIsSuccess] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const params = new URLSearchParams(window.location.search);
+  const token = params.get('token');
+  const uid = params.get('uid');
 
-  // Get token from URL
-  const urlParams = new URLSearchParams(window.location.search);
-  const token = urlParams.get("token");
+  const form = useForm<ResetForm>({ resolver: zodResolver(schema), defaultValues: { password: '', confirm: '' } });
 
-  const form = useForm<ResetPasswordForm>({
-    resolver: zodResolver(resetPasswordSchema),
-    defaultValues: {
-      newPassword: "",
-      confirmPassword: "",
-    },
-  });
-
-  // Verify token validity
-  const { data: tokenData, isLoading: isVerifying, error: tokenError } = useQuery({
-    queryKey: ["verify-reset-token", token],
-    queryFn: async () => {
-      if (!token) throw new Error("No reset token provided");
-      const response = await fetch(`/api/verify-reset-token/${token}`);
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || "Invalid token");
-      }
-      return response.json();
-    },
-    enabled: !!token,
-    retry: false,
-  });
-
-  const resetPasswordMutation = useMutation({
-    mutationFn: async (data: ResetPasswordForm) => {
-      if (!token) throw new Error("No reset token provided");
-      const response = await fetch("/api/reset-password", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          token,
-          newPassword: data.newPassword,
-        }),
-      });
-      
-      const responseData = await response.json();
-      
-      if (!response.ok) {
-        throw new Error(responseData.error || "Failed to reset password");
-      }
-      
-      return responseData;
-    },
-    onSuccess: () => {
-      setIsSuccess(true);
-      setErrorMessage(null);
-    },
-    onError: (error: any) => {
-      console.error("Reset password error:", error);
-      setErrorMessage(error.message || "Failed to reset password. Please try again.");
-    },
-  });
-
-  const onSubmit = (data: ResetPasswordForm) => {
-    setErrorMessage(null);
-    resetPasswordMutation.mutate(data);
+  const onSubmit = async (data: ResetForm) => {
+    if (!token || !uid) return;
+    const res = await fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ uid, token, newPassword: data.password }),
+    });
+    if (res.ok) {
+      toast({ title: 'Password has been reset' });
+      setLocation('/auth');
+    } else {
+      const j = await res.json();
+      toast({ title: j.message || 'Reset failed', variant: 'destructive' });
+    }
   };
 
-  // Redirect if no token
-  useEffect(() => {
-    if (!token) {
-      setLocation("/forgot-password");
-    }
-  }, [token, setLocation]);
-
-  if (!token) {
-    return null;
-  }
-
-  if (isVerifying) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 dark:from-gray-900 dark:via-blue-900 dark:to-purple-900 flex items-center justify-center p-4">
-        <div className="w-full max-w-md">
-          <Card className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg shadow-xl border-white/20 dark:border-gray-700/50">
-            <CardContent className="pt-6 text-center">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
-              <p className="text-gray-600 dark:text-gray-300">Verifying reset token...</p>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-    );
-  }
-
-  if (tokenError || !tokenData?.valid) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 dark:from-gray-900 dark:via-blue-900 dark:to-purple-900 flex items-center justify-center p-4">
-        <div className="w-full max-w-md">
-          <Card className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg shadow-xl border-white/20 dark:border-gray-700/50">
-            <CardHeader className="text-center">
-              <CardTitle className="text-2xl font-bold text-red-600">Invalid Reset Link</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center space-y-6">
-              <p className="text-gray-600 dark:text-gray-300">
-                This password reset link is invalid or has expired. Please request a new one.
-              </p>
-              <div className="space-y-3">
-                <Button
-                  onClick={() => setLocation("/forgot-password")}
-                  className="w-full h-12 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-medium"
-                >
-                  Request New Reset Link
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => setLocation("/auth")}
-                  className="w-full h-12 text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100"
-                >
-                  <ArrowLeft className="h-4 w-4 mr-2" />
-                  Back to Login
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-    );
-  }
-
-  if (isSuccess) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 dark:from-gray-900 dark:via-blue-900 dark:to-purple-900 flex items-center justify-center p-4">
-        <div className="w-full max-w-md">
-          <Card className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg shadow-xl border-white/20 dark:border-gray-700/50">
-            <CardHeader className="text-center space-y-4">
-              <div className="mx-auto w-16 h-16 bg-gradient-to-r from-green-500 to-emerald-500 rounded-full flex items-center justify-center">
-                <CheckCircle className="h-8 w-8 text-white" />
-              </div>
-              <CardTitle className="text-2xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
-                Password Reset Successful
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-center space-y-6">
-              <p className="text-gray-600 dark:text-gray-300">
-                Your password has been successfully reset. You can now log in with your new password.
-              </p>
-              <Button
-                onClick={() => setLocation("/auth")}
-                className="w-full h-12 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-medium"
-              >
-                Go to Login
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 dark:from-gray-900 dark:via-blue-900 dark:to-purple-900 flex items-center justify-center p-4">
-      <div className="w-full max-w-md">
-        <Card className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-lg shadow-xl border-white/20 dark:border-gray-700/50">
-          <CardHeader className="text-center space-y-4">
-            {/* Logo */}
-            <div className="flex justify-center">
-              <img 
-                src="/assets/logo-horizontal.png" 
-                alt="MyLinked" 
-                className="h-12 object-contain"
-                onError={(e) => {
-                  (e.currentTarget as HTMLImageElement).style.display = 'none';
-                  (e.currentTarget.nextElementSibling as HTMLElement)!.style.display = 'block';
-                }}
-              />
-              <div 
-                className="text-2xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent hidden"
-              >
-                MyLinked
-              </div>
-            </div>
-            <CardTitle className="text-2xl font-bold text-gray-900 dark:text-white">
-              Reset Password
-            </CardTitle>
-            {tokenData?.email && (
-              <p className="text-gray-600 dark:text-gray-300">
-                Resetting password for: <span className="font-medium">{tokenData.email}</span>
-              </p>
+    <div className="p-4 max-w-md mx-auto">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New Password</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-          </CardHeader>
-
-          <CardContent>
-            {errorMessage && (
-              <Alert className="mb-6 border-red-200 bg-red-50 dark:bg-red-900/20 dark:border-red-800">
-                <AlertDescription className="text-red-800 dark:text-red-300">
-                  {errorMessage}
-                </AlertDescription>
-              </Alert>
+          />
+          <FormField
+            control={form.control}
+            name="confirm"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm Password</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-
-            <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                <FormField
-                  control={form.control}
-                  name="newPassword"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>New Password</FormLabel>
-                      <FormControl>
-                        <div className="relative">
-                          <Input
-                            type={showPassword ? "text" : "password"}
-                            placeholder="Enter your new password"
-                            {...field}
-                            autoComplete="new-password"
-                            className="h-12 pr-12"
-                          />
-                          <button
-                            type="button"
-                            className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-gray-700 focus:outline-none focus:text-gray-700 cursor-pointer z-10"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              setShowPassword(!showPassword);
-                            }}
-                            onMouseDown={(e) => e.preventDefault()}
-                          >
-                            {showPassword ? (
-                              <EyeOff className="h-4 w-4" />
-                            ) : (
-                              <Eye className="h-4 w-4" />
-                            )}
-                          </button>
-                        </div>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="confirmPassword"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Confirm Password</FormLabel>
-                      <FormControl>
-                        <div className="relative">
-                          <Input
-                            type={showConfirmPassword ? "text" : "password"}
-                            placeholder="Confirm your new password"
-                            {...field}
-                            autoComplete="new-password"
-                            className="h-12 pr-12"
-                          />
-                          <button
-                            type="button"
-                            className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-gray-700 focus:outline-none focus:text-gray-700 cursor-pointer z-10"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              setShowConfirmPassword(!showConfirmPassword);
-                            }}
-                            onMouseDown={(e) => e.preventDefault()}
-                          >
-                            {showConfirmPassword ? (
-                              <EyeOff className="h-4 w-4" />
-                            ) : (
-                              <Eye className="h-4 w-4" />
-                            )}
-                          </button>
-                        </div>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <Button
-                  type="submit"
-                  className="w-full h-12 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-medium"
-                  disabled={resetPasswordMutation.isPending}
-                >
-                  {resetPasswordMutation.isPending ? "Resetting..." : "Reset Password"}
-                </Button>
-
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="w-full h-12 text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100"
-                  onClick={() => setLocation("/auth")}
-                >
-                  <ArrowLeft className="h-4 w-4 mr-2" />
-                  Back to Login
-                </Button>
-              </form>
-            </Form>
-          </CardContent>
-        </Card>
-      </div>
+          />
+          <Button type="submit" className="w-full">Reset Password</Button>
+        </form>
+      </Form>
     </div>
   );
 }

--- a/migrations/04-create-password-reset-tokens.sql
+++ b/migrations/04-create-password-reset-tokens.sql
@@ -1,0 +1,15 @@
+-- Password reset tokens (single use, short lived)
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL,              -- sha256(token)
+  expires_at TIMESTAMPTZ NOT NULL,       -- e.g. now() + interval '30 minutes'
+  used_at TIMESTAMPTZ,                   -- set once consumed
+  ip TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_prt_user_expires
+  ON password_reset_tokens(user_id, expires_at)
+  WHERE used_at IS NULL;

--- a/server/auth/password.ts
+++ b/server/auth/password.ts
@@ -1,0 +1,11 @@
+import bcrypt from 'bcrypt';
+
+const ROUNDS = 12; // match whatever login uses; adjust if different
+
+export async function hashPassword(plain: string) {
+  return bcrypt.hash(plain, ROUNDS);
+}
+
+export async function verifyPassword(plain: string, hash: string) {
+  return bcrypt.compare(plain, hash);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,9 @@ import { db } from "./db";
 import path from "path";
 import { fileURLToPath } from "url";
 import referralRequestsRouter from "./routes/referral-requests";
+import forgotPasswordRouter from "./routes/auth/forgot-password";
+import resetPasswordRouter from "./routes/auth/reset-password";
+import ownerRecoveryRouter from "./routes/auth/owner-recovery";
 // Temporarily disabled problematic imports
 // import { initializeEmailTemplates } from "./init-email-templates";
 // import { initAIEmailTemplates } from "./ai-email-templates";
@@ -148,6 +151,9 @@ app.use((req, res, next) => {
   const server = await registerRoutes(app);
 
   app.use(referralRequestsRouter);
+  app.use(forgotPasswordRouter);
+  app.use(resetPasswordRouter);
+  app.use(ownerRecoveryRouter);
 
   // Add custom domain route handler AFTER API routes are registered
   app.get('*', (req, res, next) => {

--- a/server/lib/mailer.ts
+++ b/server/lib/mailer.ts
@@ -1,0 +1,23 @@
+import sgMail from '@sendgrid/mail';
+
+export function initMailer() {
+  const key = process.env.SENDGRID_API_KEY;
+  if (!key) throw new Error('SENDGRID_API_KEY not set');
+  sgMail.setApiKey(key);
+}
+
+export async function sendPasswordResetEmail(to: string, resetUrl: string) {
+  const from = process.env.SENDGRID_FROM_EMAIL || 'no-reply@example.com';
+  const msg = {
+    to,
+    from,
+    subject: 'Reset your password',
+    text: `Click the link to reset your password: ${resetUrl}`,
+    html: `
+      <p>We received a request to reset your password.</p>
+      <p><a href="${resetUrl}" target="_blank" rel="noopener">Reset your password</a></p>
+      <p>This link expires in 30 minutes. If you did not request this, you can ignore this email.</p>
+    `,
+  };
+  await sgMail.send(msg);
+}

--- a/server/routes/auth/forgot-password.ts
+++ b/server/routes/auth/forgot-password.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express';
+import crypto from 'crypto';
+import { db } from '../../db';
+import { sql } from 'drizzle-orm';
+import { initMailer, sendPasswordResetEmail } from '../../lib/mailer';
+
+const router = Router();
+
+// simple in-memory rate-limit per IP (best-effort)
+const lastReq = new Map<string, number>();
+function rateLimited(ip: string, ms: number) {
+  const now = Date.now();
+  const prev = lastReq.get(ip) || 0;
+  if (now - prev < ms) return true;
+  lastReq.set(ip, now);
+  return false;
+}
+
+router.post('/api/auth/forgot-password', async (req, res, next) => {
+  try {
+    const ip = req.ip || (req.headers['x-forwarded-for'] as string) || '';
+    if (rateLimited(ip, 30_000)) return res.status(429).json({ message: 'Too many requests' });
+
+    const { email, username } = req.body || {};
+    if (!email && !username) return res.status(400).json({ message: 'email or username is required' });
+
+    // find user by email or username
+    const userResult = await db.execute(sql`
+      SELECT id, email FROM users
+      WHERE ${email ? sql`email = ${email}` : sql`username = ${username}`}
+      LIMIT 1
+    `);
+    const user = userResult.rows?.[0];
+    // Don't reveal existence; always reply 200
+    if (!user) return res.json({ message: 'If your account exists, you will receive an email shortly.' });
+
+    const token = crypto.randomBytes(32).toString('hex');
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const expiresAt = sql`NOW() + INTERVAL '30 minutes'`;
+
+    await db.execute(sql`
+      INSERT INTO password_reset_tokens (user_id, token_hash, expires_at, ip, user_agent)
+      VALUES (${user.id}, ${tokenHash}, ${expiresAt}, ${ip}, ${req.headers['user-agent'] || null})
+    `);
+
+    const base = process.env.APP_BASE_URL || 'http://localhost:3000';
+    const resetUrl = `${base}/reset-password?token=${token}&uid=${user.id}`;
+
+    initMailer();
+    await sendPasswordResetEmail(user.email || email, resetUrl);
+
+    return res.json({ message: 'If your account exists, you will receive an email shortly.' });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/server/routes/auth/owner-recovery.ts
+++ b/server/routes/auth/owner-recovery.ts
@@ -1,0 +1,55 @@
+import { Router } from 'express';
+import crypto from 'crypto';
+import { db } from '../../db';
+import { sql } from 'drizzle-orm';
+import { hashPassword } from '../../auth/password';
+
+const router = Router();
+
+function verifyHmac(secret: string, payload: string, headerSig: string) {
+  const h = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(h), Buffer.from(headerSig));
+}
+
+router.post('/api/auth/owner-recovery', async (req, res, next) => {
+  try {
+    const secret = process.env.OWNER_RECOVERY_SECRET;
+    if (!secret) return res.status(503).json({ message: 'OWNER_RECOVERY_SECRET not set' });
+
+    const sig = req.header('x-owner-recovery-sig') || '';
+    const ts = req.header('x-owner-recovery-ts') || '';
+    const now = Date.now();
+    const tsNum = parseInt(ts, 10);
+    if (!tsNum || Math.abs(now - tsNum) > 10 * 60 * 1000) {
+      return res.status(400).json({ message: 'Invalid timestamp' });
+    }
+
+    const bodyStr = JSON.stringify(req.body || {});
+    if (!verifyHmac(secret, ts + ':' + bodyStr, sig)) {
+      return res.status(401).json({ message: 'Invalid signature' });
+    }
+
+    const { username, email, newPassword } = req.body || {};
+    if (!newPassword || (!username && !email)) {
+      return res.status(400).json({ message: 'newPassword and username or email are required' });
+    }
+
+    // Lookup user
+    const usrRes = await db.execute(sql`
+      SELECT id FROM users
+      WHERE ${username ? sql`username = ${username}` : sql`email = ${email}`}
+      LIMIT 1
+    `);
+    const usr = usrRes.rows?.[0];
+    if (!usr) return res.status(404).json({ message: 'User not found' });
+
+    const hashed = await hashPassword(newPassword);
+    await db.execute(sql`UPDATE users SET password = ${hashed}, updated_at = NOW() WHERE id = ${usr.id}`);
+
+    return res.json({ message: 'Password updated via owner recovery' });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/server/routes/auth/reset-password.ts
+++ b/server/routes/auth/reset-password.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import crypto from 'crypto';
+import { db } from '../../db';
+import { sql } from 'drizzle-orm';
+import { hashPassword } from '../../auth/password';
+
+const router = Router();
+
+router.post('/api/auth/reset-password', async (req, res, next) => {
+  try {
+    const { uid, token, newPassword } = req.body || {};
+    if (!uid || !token || !newPassword) {
+      return res.status(400).json({ message: 'uid, token, and newPassword are required' });
+    }
+
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+
+    // Find a valid, unused token
+    const tokRes = await db.execute(sql`
+      SELECT id, expires_at, used_at
+      FROM password_reset_tokens
+      WHERE user_id = ${uid} AND token_hash = ${tokenHash}
+      LIMIT 1
+    `);
+    const row = tokRes.rows?.[0];
+    if (!row) return res.status(400).json({ message: 'Invalid token' });
+
+    // Check expiry / used
+    const isUsed = row.used_at != null;
+    const isExpired = new Date(row.expires_at) < new Date();
+    if (isUsed || isExpired) {
+      return res.status(400).json({ message: 'Token expired or already used' });
+    }
+
+    // Update password
+    const hashed = await hashPassword(newPassword);
+    // NOTE: adjust COL_PASS to your actual column ('password' or 'password_hash')
+    await db.execute(sql`UPDATE users SET password = ${hashed}, updated_at = NOW() WHERE id = ${uid}`);
+
+    // Mark token used
+    await db.execute(sql`UPDATE password_reset_tokens SET used_at = NOW() WHERE id = ${row.id}`);
+
+    // (optional) Invalidate sessions here if you store them in DB
+
+    return res.json({ message: 'Password has been reset successfully' });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add password_reset_tokens table for single-use reset tokens
- add bcrypt-based password helpers and SendGrid mailer
- implement forgot-password, reset-password, and owner-recovery APIs
- add simple frontend pages for requesting and completing password resets

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b47c89f3b4832ca445ac8ef7e80a05