### PR TITLE
Align user ID schema and fix login

### DIFF
--- a/client/src/hooks/useNotifications.ts
+++ b/client/src/hooks/useNotifications.ts
@@ -9,7 +9,7 @@ export type NotificationItem = {
   link?: string;
 };
 
-export function useNotifications(userId?: string) {
+export function useNotifications(userId?: number) {
   const enabled = Boolean(userId);
 
   return useQuery<NotificationItem[]>({
@@ -35,11 +35,11 @@ export function useNotifications(userId?: string) {
 export function useNotificationsActions() {
   const qc = useQueryClient();
   return {
-    invalidateByUser: async (userId?: string) =>
+    invalidateByUser: async (userId?: number) =>
       qc.invalidateQueries({ queryKey: ['notifications', userId] }),
     removeAll: async () =>
       qc.removeQueries({ queryKey: ['notifications'] }),
-    setWarmData: (userId: string, data: NotificationItem[]) =>
+    setWarmData: (userId: number, data: NotificationItem[]) =>
       qc.setQueryData(['notifications', userId], data),
   };
 }

--- a/server/db-storage-enhanced.ts
+++ b/server/db-storage-enhanced.ts
@@ -370,7 +370,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   // Link methods
-  async getLinks(userId: string): Promise<Link[]> {
+  async getLinks(userId: number): Promise<Link[]> {
     return db
       .select()
       .from(links)
@@ -388,7 +388,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   // Backfill links that have null owner to the provided user
-  async createLink(userId: string, linkData: any): Promise<Link> {
+  async createLink(userId: number, linkData: any): Promise<Link> {
     // Get the count of existing links to set the order
     const [result] = await db
       .select({ count: count() })
@@ -427,7 +427,7 @@ export class EnhancedDatabaseStorage implements IStorage {
     return link;
   }
 
-  async deleteLink(id: number, userId?: string): Promise<boolean> {
+  async deleteLink(id: number, userId?: number): Promise<boolean> {
     if (userId) {
       const result = await db
         .delete(links)
@@ -440,7 +440,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   // Delete link enforcing ownership but allowing legacy null owners
-  async deleteLinkOwned(id: number, userId: string): Promise<boolean> {
+  async deleteLinkOwned(id: number, userId: number): Promise<boolean> {
     const res = await db
       .delete(links)
       .where(and(eq(links.id, id), eq(links.userId, userId)));
@@ -1069,7 +1069,7 @@ export class EnhancedDatabaseStorage implements IStorage {
     `);
   }
 
-  async getSkills(userId: string): Promise<any[]> {
+  async getSkills(userId: number): Promise<any[]> {
     await this.ensureUserSkillsTable();
     try {
       const rows = await db.execute(
@@ -1146,7 +1146,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   // Referral Links Feature
-  async getReferralLinks(userId: string): Promise<ReferralLink[]> {
+  async getReferralLinks(userId: number): Promise<ReferralLink[]> {
     return await db
       .select()
       .from(referralLinks)
@@ -1162,7 +1162,7 @@ export class EnhancedDatabaseStorage implements IStorage {
     return link;
   }
 
-  async createReferralLink(userId: string, link: InsertReferralLink): Promise<ReferralLink> {
+  async createReferralLink(userId: number, link: InsertReferralLink): Promise<ReferralLink> {
     const [newLink] = await db
       .insert(referralLinks)
       .values({
@@ -1903,7 +1903,7 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   // Skills methods that are missing
-  async addUserSkill(userId: string, skill: string, level: number = 3): Promise<any> {
+  async addUserSkill(userId: number, skill: string, level: number = 3): Promise<any> {
     await this.ensureUserSkillsTable();
     const result = await db.execute(
       sql`INSERT INTO user_skills (user_id, skill, level)

--- a/server/db-storage-new-features.ts
+++ b/server/db-storage-new-features.ts
@@ -83,7 +83,7 @@ export class EnhancedDatabaseStorage extends BaseStorage {
   // Referral Links Feature
 
   // Get all referral links for a user
-  async getReferralLinks(userId: string): Promise<ReferralLink[]> {
+  async getReferralLinks(userId: number): Promise<ReferralLink[]> {
     return await db
       .select()
       .from(referralLinks)
@@ -101,7 +101,7 @@ export class EnhancedDatabaseStorage extends BaseStorage {
   }
 
   // Create a new referral link
-  async createReferralLink(userId: string, link: InsertReferralLink): Promise<ReferralLink> {
+  async createReferralLink(userId: number, link: InsertReferralLink): Promise<ReferralLink> {
     const [newLink] = await db
       .insert(referralLinks)
       .values({

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -52,12 +52,12 @@ export interface IStorage {
   resetPassword(token: string, newPassword: string): Promise<User | undefined>;
   
   // Links
-  getLinks(userId: string): Promise<Link[]>;
+  getLinks(userId: number): Promise<Link[]>;
   getLinkById(id: number): Promise<Link | undefined>;
-  createLink(userId: string, link: InsertLink): Promise<Link>;
+  createLink(userId: number, link: InsertLink): Promise<Link>;
   updateLink(id: number, updates: UpdateLink): Promise<Link | undefined>;
-  deleteLink(id: number, userId?: string): Promise<boolean>;
-  deleteLinkOwned(id: number, userId: string): Promise<boolean>;
+  deleteLink(id: number, userId?: number): Promise<boolean>;
+  deleteLinkOwned(id: number, userId: number): Promise<boolean>;
   incrementLinkClicks(id: number): Promise<Link | undefined>;
   incrementLinkViews(id: number): Promise<Link | undefined>;
   updateLinkAiScore(id: number, score: number): Promise<Link | undefined>;
@@ -111,9 +111,9 @@ export interface IStorage {
   discoverUsers(userId: number, filters: any): Promise<User[]>;
   
   // Referral Links Feature
-  getReferralLinks(userId: string): Promise<ReferralLink[]>;
+  getReferralLinks(userId: number): Promise<ReferralLink[]>;
   getReferralLinkById(id: number): Promise<ReferralLink | undefined>;
-  createReferralLink(userId: string, link: InsertReferralLink): Promise<ReferralLink>;
+  createReferralLink(userId: number, link: InsertReferralLink): Promise<ReferralLink>;
   updateReferralLink(id: number, updates: Partial<InsertReferralLink>): Promise<ReferralLink | undefined>;
   deleteReferralLink(id: number): Promise<boolean>;
   incrementReferralLinkClicks(id: number): Promise<ReferralLink | undefined>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, timestamp, integer, json, boolean, varchar, jsonb, decimal, uuid } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, timestamp, integer, json, boolean, varchar, jsonb, decimal } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 import { relations, sql } from "drizzle-orm";
@@ -14,7 +14,7 @@ export const sessions = pgTable("sessions", {
 export const oauthStates = pgTable("oauth_states", {
   id: serial("id").primaryKey(),
   state: text("state").notNull().unique(),
-  userId: uuid("user_id").notNull(),
+  userId: integer("user_id").notNull(),
   platform: text("platform").notNull(),
   codeVerifier: text("code_verifier"),
   createdAt: timestamp("created_at").defaultNow(),
@@ -31,7 +31,7 @@ export const industries = pgTable("industries", {
 
 // Users table
 export const users = pgTable("users", {
-  id: uuid("id").defaultRandom().primaryKey(),
+  id: serial("id").primaryKey(),
   username: text("username").notNull().unique(),
   password: text("password").notNull(),
   name: text("name").notNull(),
@@ -86,7 +86,7 @@ export const passwordResetTokens = pgTable("password_reset_tokens", {
 // User themes table for custom theme preferences
 export const userThemes = pgTable("user_themes", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  userId: integer("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
   themeId: text("theme_id").notNull(),
   name: text("name").notNull(),
   colors: jsonb("colors").notNull(),
@@ -103,7 +103,7 @@ export const featureToggles = pgTable("feature_toggles", {
   featureName: text("feature_name").notNull().unique(),
   isEnabled: boolean("is_enabled").default(true),
   description: text("description"),
-  updatedBy: uuid("updated_by").references(() => users.id),
+  updatedBy: integer("updated_by").references(() => users.id),
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
@@ -113,7 +113,7 @@ export const systemLogs = pgTable("system_logs", {
   level: text("level").notNull(), // error, warning, info
   message: text("message").notNull(),
   source: text("source"), // oauth, api, auth, etc.
-  userId: uuid("user_id").references(() => users.id),
+  userId: integer("user_id").references(() => users.id),
   metadata: jsonb("metadata"),
   createdAt: timestamp("created_at").defaultNow(),
 });
@@ -141,21 +141,21 @@ export const permissions = pgTable("permissions", {
 
 export const userRoles = pgTable("user_roles", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  userId: integer("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
   roleId: integer("role_id").references(() => roles.id, { onDelete: "cascade" }).notNull(),
-  assignedBy: uuid("assigned_by").references(() => users.id),
+  assignedBy: integer("assigned_by").references(() => users.id),
   assignedAt: timestamp("assigned_at").defaultNow(),
 });
 
 export const employeeProfiles = pgTable("employee_profiles", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  userId: integer("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
   employeeId: varchar("employee_id", { length: 20 }).unique(),
   department: varchar("department", { length: 100 }),
   position: varchar("position", { length: 100 }),
   salary: integer("salary"),
   hireDate: timestamp("hire_date"),
-  manager: uuid("manager").references(() => users.id),
+  manager: integer("manager").references(() => users.id),
   workLocation: varchar("work_location", { length: 100 }),
   workType: varchar("work_type", { length: 50 }), // full-time, part-time, contract, intern
   status: varchar("status", { length: 50 }).default("active"), // active, inactive, terminated
@@ -184,13 +184,13 @@ export const userThemesRelations = relations(userThemes, ({ one }) => ({
 // Referral Links table
 export const referralLinks = pgTable("referral_links", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  userId: integer("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   title: text("title").notNull(),
   url: text("url").notNull(),
   description: text("description"),
   image: text("image"), // Small logo or profile image
   linkType: text("link_type").notNull().default("friend"), // friend, sponsor, affiliate
-  referenceUserId: uuid("reference_user_id").references(() => users.id),
+  referenceUserId: integer("reference_user_id").references(() => users.id),
   referenceCompany: text("reference_company"),
   clicks: integer("clicks").default(0),
   createdAt: timestamp("created_at").defaultNow(),
@@ -227,7 +227,7 @@ export const usersRelations = relations(users, ({ many, one }) => ({
 // Links table
 export const links = pgTable("links", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  userId: integer("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   platform: text("platform").notNull(),
   title: text("title").notNull(),
   url: text("url").notNull(),
@@ -254,7 +254,7 @@ export const linksRelations = relations(links, ({ one }) => ({
 // Profile views table
 export const profileViews = pgTable("profile_views", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  userId: integer("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   viewedAt: timestamp("viewed_at").defaultNow(),
   referrer: text("referrer"),
   userAgent: text("user_agent"),
@@ -272,8 +272,8 @@ export const profileViewsRelations = relations(profileViews, ({ one }) => ({
 // Follows table
 export const follows = pgTable("follows", {
   id: serial("id").primaryKey(),
-  followerId: uuid("follower_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
-  followingId: uuid("following_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  followerId: integer("follower_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  followingId: integer("following_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -294,7 +294,7 @@ export const followsRelations = relations(follows, ({ one }) => ({
 // Social media connections table for OAuth tokens
 export const socialConnections = pgTable("social_connections", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  userId: integer("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   platform: text("platform").notNull(), // instagram, facebook, linkedin, twitter, tiktok
   accessToken: text("access_token").notNull(),
   refreshToken: text("refresh_token"),
@@ -308,7 +308,7 @@ export const socialConnections = pgTable("social_connections", {
 // Instagram content preview table - replaces Live Profile Feed
 export const instagramPreviews = pgTable("instagram_previews", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  userId: integer("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   postId: text("post_id").notNull().unique(), // Instagram media ID
   imageUrl: text("image_url").notNull(),
   thumbnailUrl: text("thumbnail_url"),
@@ -323,7 +323,7 @@ export const instagramPreviews = pgTable("instagram_previews", {
 // Social posts table (kept for other platforms)
 export const socialPosts = pgTable("social_posts", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  userId: integer("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   platform: text("platform").notNull(), // facebook, tiktok, youtube, etc.
   postUrl: text("post_url").notNull(),
   thumbnailUrl: text("thumbnail_url"),
@@ -527,7 +527,7 @@ export type ProfileStats = {
 // Collaborative Spotlight Projects
 export const spotlightProjects = pgTable("spotlight_projects", {
   id: serial("id").primaryKey(),
-  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  userId: integer("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
   title: varchar("title", { length: 100 }).notNull(),
   url: varchar("url", { length: 1000 }).notNull(),
   description: text("description"),
@@ -551,7 +551,7 @@ export const spotlightProjectsRelations = relations(spotlightProjects, ({ many, 
 export const spotlightContributors = pgTable("spotlight_contributors", {
   id: serial("id").primaryKey(),
   projectId: integer("project_id").notNull().references(() => spotlightProjects.id, { onDelete: "cascade" }),
-  userId: uuid("user_id").references(() => users.id),
+  userId: integer("user_id").references(() => users.id),
   name: varchar("name", { length: 100 }).notNull(),
   email: varchar("email", { length: 255 }),
   role: varchar("role", { length: 50 }),
@@ -588,7 +588,7 @@ export const spotlightTagsRelations = relations(spotlightTags, ({ one }) => ({
 // Referral requests table for notifications
 export const referralRequests = pgTable("referral_requests", {
   id: serial("id").primaryKey(),
-  targetUserId: uuid("target_user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  targetUserId: integer("target_user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
   requesterName: varchar("requester_name", { length: 100 }).notNull(),
   requesterEmail: varchar("requester_email", { length: 255 }).notNull(),
   requesterPhone: varchar("requester_phone", { length: 50 }),
@@ -629,7 +629,7 @@ export const updateReferralRequestSchema = createInsertSchema(referralRequests).
 // Collaboration requests table for notifications - different from the existing collaboration system
 export const collaborationRequestsNotifications = pgTable("collaboration_requests_notifications", {
   id: serial("id").primaryKey(),
-  targetUserId: uuid("target_user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  targetUserId: integer("target_user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
   requesterName: varchar("requester_name", { length: 100 }).notNull(),
   requesterEmail: varchar("requester_email", { length: 255 }).notNull(),
   requesterCompany: varchar("requester_company", { length: 255 }),
@@ -673,7 +673,7 @@ export type ContributorInput = {
   email?: string;
   role?: string;
   isRegisteredUser?: boolean;
-  userId?: string;
+  userId?: number;
 };
 
 export type TagInput = {
@@ -698,7 +698,7 @@ export const createSpotlightProjectSchema = createInsertSchema(spotlightProjects
         email: z.string().email().optional(),
         role: z.string().optional(),
         isRegisteredUser: z.boolean().optional().default(false),
-        userId: z.string().optional(),
+        userId: z.number().optional(),
       })
     ).optional(),
     tags: z.array(
@@ -771,12 +771,12 @@ export const userReports = pgTable("user_reports", {
   id: serial("id").primaryKey(),
   reporterName: text("reporter_name"),
   reporterEmail: text("reporter_email"),
-  reportedUserId: uuid("reported_user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  reportedUserId: integer("reported_user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   reportedUsername: text("reported_username"),
   reason: text("reason").notNull(), // harassment, inappropriate_content, spam, fake_account, copyright_violation, other
   description: text("description").notNull(),
   status: text("status").default("pending"), // pending, reviewed, resolved, dismissed
-  reviewedBy: uuid("reviewed_by").references(() => users.id),
+  reviewedBy: integer("reviewed_by").references(() => users.id),
   adminNotes: text("admin_notes"),
   createdAt: timestamp("created_at").defaultNow(),
   reviewedAt: timestamp("reviewed_at"),
@@ -846,8 +846,8 @@ export type UpdateUserReport = z.infer<typeof updateUserReportSchema>;
 // Collaboration Requests table (new clean implementation)
 export const collaborationRequests = pgTable("collaboration_requests", {
   id: serial("id").primaryKey(),
-  senderId: uuid("sender_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
-  receiverId: uuid("receiver_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  senderId: integer("sender_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  receiverId: integer("receiver_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
   name: text("name").notNull(),
   email: text("email").notNull(),
   phone: text("phone"),

--- a/shared/schema/index.ts
+++ b/shared/schema/index.ts
@@ -1,7 +1,7 @@
-import { pgTable, varchar, timestamp, uuid } from "drizzle-orm/pg-core";
+import { pgTable, varchar, timestamp, serial } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
-  id: uuid("id").primaryKey().defaultRandom(),
+  id: serial("id").primaryKey(),
   email: varchar("email", { length: 255 }).notNull(),
   createdAt: timestamp("created_at").defaultNow(),
 });


### PR DESCRIPTION
## Summary
- switch user table and references to numeric IDs to match the database
- update server storage methods to accept numeric user IDs
- adjust notifications hook to work with numeric IDs

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*


------
https://chatgpt.com/codex/tasks/task_e_68b72678ef74832cbd92e2c4f5027740