### PR TITLE
Fix admin user tab search and filters

### DIFF
--- a/client/src/pages/enhanced-admin-panel.tsx
+++ b/client/src/pages/enhanced-admin-panel.tsx
@@ -189,8 +189,8 @@ export default function EnhancedAdminPanel() {
                          u.username?.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          u.email?.toLowerCase().includes(searchTerm.toLowerCase());
     
-    const matchesFilter = userFilter === "all" || 
-                         (userFilter === "admin" && u.role === 'admin') ||
+    const matchesFilter = userFilter === "all" ||
+                         (userFilter === "admin" && (u.role === 'admin' || u.isAdmin)) ||
                          (userFilter === "active" && u.isActive !== false) ||
                          (userFilter === "inactive" && u.isActive === false);
     

--- a/client/src/pages/professional-admin-panel.tsx
+++ b/client/src/pages/professional-admin-panel.tsx
@@ -637,7 +637,7 @@ export default function ProfessionalAdminPanel() {
                       <TableHead className="w-12">
                         <input
                           type="checkbox"
-                          checked={selectedUsers.length === filteredUsers.length}
+                          checked={filteredUsers.length > 0 && selectedUsers.length === filteredUsers.length}
                           onChange={(e) => {
                             if (e.target.checked) {
                               setSelectedUsers(filteredUsers.map(u => u.id));

--- a/server/admin-routes.ts
+++ b/server/admin-routes.ts
@@ -30,6 +30,7 @@ adminRouter.get("/users", async (req: Request, res: Response) => {
         username: users.username,
         name: users.name,
         email: users.email,
+        role: users.role,
         bio: users.bio,
         location: users.location,
         isAdmin: users.isAdmin,


### PR DESCRIPTION
## Summary
- Include user role in admin user API
- Ensure admin filter checks role or admin flag
- Avoid selecting checkbox when no users

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d88ad4a4832c91816433bf186e16